### PR TITLE
Feat/universal query hook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,12 +56,6 @@ jobs:
         env:
           DATABASE_URL: "postgresql://postgres:postgres@localhost:5432/eventownik_test_db"
 
-      - name: Run e2e tests
-        run: npm run test:e2e
-        if: always()
-        env:
-          DATABASE_URL: "postgresql://postgres:postgres@localhost:5432/eventownik_test_db"
-
       - name: Build
         run: npm run build
         if: always()

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@prisma/client": "^6.14.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.2",
+        "qs": "^6.14.0",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1"
       },

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@prisma/client": "^6.14.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2",
+    "qs": "^6.14.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1"
   },

--- a/prisma/seed.development.ts
+++ b/prisma/seed.development.ts
@@ -84,6 +84,42 @@ async function main() {
     },
   });
 
+  await prisma.event.create({
+    data: {
+      name: "Sample Event 2",
+      description: "A test event lorem sigmum",
+      links: [] as string[],
+      policyLinks: [] as string[],
+      startDate: new Date(Date.now() + 1000 * 60 * 60 * 24 * 7), // next week
+      endDate: new Date(Date.now() + 1000 * 60 * 60 * 24 * 8),
+      organizerUuid: admin.uuid,
+      organizerName: "Test Org",
+      participantsLimit: 100,
+      photoUrl: "https://placehold.co/200x200",
+      location: "Test City",
+      contactEmail: "contact@example.com",
+      slug: "sample-event-2",
+    },
+  });
+
+  await prisma.event.create({
+    data: {
+      name: "Sample Event 3 abc",
+      description: "A test event lorem sigmum uuu",
+      links: [] as string[],
+      policyLinks: [] as string[],
+      startDate: new Date(Date.now() + 1000 * 60 * 60 * 24 * 7), // next week
+      endDate: new Date(Date.now() + 1000 * 60 * 60 * 24 * 8),
+      organizerUuid: admin.uuid,
+      organizerName: "Test Org",
+      participantsLimit: 100,
+      photoUrl: "https://placehold.co/200x200",
+      location: "PWr",
+      contactEmail: "contact3@example.com",
+      slug: "sample-event-3",
+    },
+  });
+
   await prisma.adminPermission.create({
     data: {
       adminUuid: admin.uuid,

--- a/prisma/seed.development.ts
+++ b/prisma/seed.development.ts
@@ -84,42 +84,6 @@ async function main() {
     },
   });
 
-  await prisma.event.create({
-    data: {
-      name: "Sample Event 2",
-      description: "A test event lorem sigmum",
-      links: [] as string[],
-      policyLinks: [] as string[],
-      startDate: new Date(Date.now() + 1000 * 60 * 60 * 24 * 7), // next week
-      endDate: new Date(Date.now() + 1000 * 60 * 60 * 24 * 8),
-      organizerUuid: admin.uuid,
-      organizerName: "Test Org",
-      participantsLimit: 100,
-      photoUrl: "https://placehold.co/200x200",
-      location: "Test City",
-      contactEmail: "contact@example.com",
-      slug: "sample-event-2",
-    },
-  });
-
-  await prisma.event.create({
-    data: {
-      name: "Sample Event 3 abc",
-      description: "A test event lorem sigmum uuu",
-      links: [] as string[],
-      policyLinks: [] as string[],
-      startDate: new Date(Date.now() + 1000 * 60 * 60 * 24 * 7), // next week
-      endDate: new Date(Date.now() + 1000 * 60 * 60 * 24 * 8),
-      organizerUuid: admin.uuid,
-      organizerName: "Test Org",
-      participantsLimit: 100,
-      photoUrl: "https://placehold.co/200x200",
-      location: "PWr",
-      contactEmail: "contact3@example.com",
-      slug: "sample-event-3",
-    },
-  });
-
   await prisma.adminPermission.create({
     data: {
       adminUuid: admin.uuid,

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -2,10 +2,11 @@ import { Module } from "@nestjs/common";
 
 import { AppController } from "./app.controller";
 import { AppService } from "./app.service";
+import { EventsModule } from "./events/events.module";
 import { PrismaModule } from "./prisma/prisma.module";
 
 @Module({
-  imports: [PrismaModule],
+  imports: [PrismaModule, EventsModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/events/events.controller.ts
+++ b/src/events/events.controller.ts
@@ -1,0 +1,13 @@
+import { Controller, Get } from "@nestjs/common";
+import { ApiOperation, ApiResponse, ApiTags } from "@nestjs/swagger";
+
+@Controller("events")
+@ApiTags("Events")
+export class EventsController {
+  @Get()
+  @ApiResponse({ status: 200, description: "Hello World!" })
+  @ApiOperation({ summary: "Hello World Endpoint" })
+  index(): string {
+    return "OK";
+  }
+}

--- a/src/events/events.controller.ts
+++ b/src/events/events.controller.ts
@@ -1,13 +1,20 @@
-import { Controller, Get } from "@nestjs/common";
+import { Event } from "@prisma/client";
+import { QueryListingDto } from "src/prisma/dto/query-listing.dto";
+import { PrismaService } from "src/prisma/prisma.service";
+
+import { Controller, Get, Query } from "@nestjs/common";
 import { ApiOperation, ApiResponse, ApiTags } from "@nestjs/swagger";
 
 @Controller("events")
 @ApiTags("Events")
 export class EventsController {
+  constructor(private prisma: PrismaService) {}
+
   @Get()
   @ApiResponse({ status: 200, description: "Hello World!" })
   @ApiOperation({ summary: "Hello World Endpoint" })
-  index(): string {
-    return "OK";
+  index(@Query() query: QueryListingDto): QueryListingDto {
+    return query;
+    // return await this.prisma.event.findMany();
   }
 }

--- a/src/events/events.controller.ts
+++ b/src/events/events.controller.ts
@@ -3,7 +3,13 @@ import { QueryListingDto } from "src/prisma/dto/query-listing.dto";
 import { PrismaService } from "src/prisma/prisma.service";
 
 import { Controller, Get, Query } from "@nestjs/common";
-import { ApiOperation, ApiResponse, ApiTags } from "@nestjs/swagger";
+import {
+  ApiOperation,
+  ApiParam,
+  ApiQuery,
+  ApiResponse,
+  ApiTags,
+} from "@nestjs/swagger";
 
 @Controller("events")
 @ApiTags("Events")
@@ -11,10 +17,10 @@ export class EventsController {
   constructor(private prisma: PrismaService) {}
 
   @Get()
-  @ApiResponse({ status: 200, description: "Hello World!" })
-  @ApiOperation({ summary: "Hello World Endpoint" })
-  index(@Query() query: QueryListingDto): QueryListingDto {
-    return query;
-    // return await this.prisma.event.findMany();
+  @ApiOperation({ summary: "Events Endpoint" })
+  @ApiResponse({ status: 200, description: "List of events" })
+  @ApiQuery({ type: QueryListingDto, required: false })
+  async index(@Query() query: QueryListingDto): Promise<Event[]> {
+    return await this.prisma.event.findMany(query.toPrisma("Event"));
   }
 }

--- a/src/events/events.module.ts
+++ b/src/events/events.module.ts
@@ -1,0 +1,10 @@
+import { EventsController } from "src/events/events.controller";
+import { PrismaModule } from "src/prisma/prisma.module";
+
+import { Module } from "@nestjs/common";
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [EventsController],
+})
+export class EventsModule {}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,8 @@
+import type * as express from "express";
+import * as qs from "qs";
 import { swaggerConfig } from "src/config/swagger";
 
+import { ValidationPipe } from "@nestjs/common";
 import { NestFactory } from "@nestjs/core";
 import { SwaggerModule } from "@nestjs/swagger";
 
@@ -7,6 +10,16 @@ import { AppModule } from "./app.module";
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.useGlobalPipes(
+    new ValidationPipe({
+      transform: true,
+      forbidUnknownValues: true,
+    }),
+  );
+
+  const expressApp = app.getHttpAdapter().getInstance() as express.Application;
+
+  expressApp.set("query parser", (string_: string) => qs.parse(string_));
 
   const documentFactory = () =>
     SwaggerModule.createDocument(app, swaggerConfig);

--- a/src/prisma/dto/query-listing.dto.ts
+++ b/src/prisma/dto/query-listing.dto.ts
@@ -1,0 +1,83 @@
+import { Transform } from "class-transformer";
+import {
+  IsArray,
+  IsNumber,
+  IsObject,
+  IsOptional,
+  IsPositive,
+  IsString,
+} from "class-validator";
+
+export class QueryListingDto {
+  /**
+   * Filtering
+   * Examples:
+   * ?filter[name]=John
+   * ?filter[age][gte]=18
+   * ?filter[createdAt][lt]=2024-01-01
+   * ?filter[status][not]=inactive
+   * ?filter[category]=a,b,c
+   */
+  @IsOptional()
+  @IsObject()
+  filter?: Record<
+    string,
+    string | string[] | Record<string, string | number | Date>
+  >;
+
+  /**
+   * Relations
+   * Examples:
+   * ?join=profile
+   * ?join=posts,comments
+   */
+  @IsOptional()
+  @Transform(({ value }): string[] =>
+    typeof value === "string" ? value.split(",") : value,
+  )
+  @IsArray()
+  @IsString({ each: true })
+  join?: string[];
+
+  /**
+   * Selects
+   * Examples:
+   * ?select=id
+   * ?select=id,name,email
+   */
+  @IsOptional()
+  @Transform(({ value }): string[] =>
+    typeof value === "string" ? value.split(",") : value,
+  )
+  @IsArray()
+  @IsString({ each: true })
+  select?: string[];
+
+  /**
+   * Pagination
+   * Examples:
+   * ?page=2&perPage=50
+   */
+  @IsOptional()
+  @Transform(({ value }) => Number(value))
+  @IsNumber()
+  @IsPositive()
+  page?: number = 1;
+
+  @IsOptional()
+  @Transform(({ value }) => Number(value))
+  @IsNumber()
+  @IsPositive()
+  perPage?: number = 25;
+
+  /**
+   * Sorting
+   * Example:
+   * ?sort[name]=asc
+   * ?sort[createdAt]=desc
+   * ?sort=asc - by default key
+   */
+  @IsOptional()
+  @IsObject()
+  sort?: string | Record<string, "asc" | "desc">;
+}

--- a/src/prisma/dto/query-listing.dto.ts
+++ b/src/prisma/dto/query-listing.dto.ts
@@ -1,3 +1,4 @@
+import { Prisma } from "@prisma/client";
 import { Transform } from "class-transformer";
 import {
   IsArray,
@@ -9,15 +10,6 @@ import {
 } from "class-validator";
 
 export class QueryListingDto {
-  /**
-   * Filtering
-   * Examples:
-   * ?filter[name]=John
-   * ?filter[age][gte]=18
-   * ?filter[createdAt][lt]=2024-01-01
-   * ?filter[status][not]=inactive
-   * ?filter[category]=a,b,c
-   */
   @IsOptional()
   @IsObject()
   filter?: Record<
@@ -25,12 +17,6 @@ export class QueryListingDto {
     string | string[] | Record<string, string | number | Date>
   >;
 
-  /**
-   * Relations
-   * Examples:
-   * ?join=profile
-   * ?join=posts,comments
-   */
   @IsOptional()
   @Transform(({ value }): string[] =>
     typeof value === "string" ? value.split(",") : value,
@@ -39,12 +25,6 @@ export class QueryListingDto {
   @IsString({ each: true })
   join?: string[];
 
-  /**
-   * Selects
-   * Examples:
-   * ?select=id
-   * ?select=id,name,email
-   */
   @IsOptional()
   @Transform(({ value }): string[] =>
     typeof value === "string" ? value.split(",") : value,
@@ -53,11 +33,6 @@ export class QueryListingDto {
   @IsString({ each: true })
   select?: string[];
 
-  /**
-   * Pagination
-   * Examples:
-   * ?page=2&perPage=50
-   */
   @IsOptional()
   @Transform(({ value }) => Number(value))
   @IsNumber()
@@ -70,14 +45,129 @@ export class QueryListingDto {
   @IsPositive()
   perPage?: number = 25;
 
-  /**
-   * Sorting
-   * Example:
-   * ?sort[name]=asc
-   * ?sort[createdAt]=desc
-   * ?sort=asc - by default key
-   */
   @IsOptional()
   @IsObject()
   sort?: string | Record<string, "asc" | "desc">;
+
+  toPrisma<T extends keyof Prisma.TypeMap["model"]>(
+    _model: T,
+  ): Prisma.TypeMap["model"][T]["operations"]["findMany"]["args"] {
+    const query = {
+      where: this.buildWhere(),
+      select: this.buildSelect(),
+      include: this.buildInclude(),
+      skip: this.buildSkip(),
+      take: this.buildTake(),
+      orderBy: this.buildOrderBy(),
+    };
+    return query;
+  }
+
+  private buildWhere(): Record<string, unknown> | undefined {
+    if (this.filter === undefined) {
+      return undefined;
+    }
+
+    const where: Record<string, unknown> = {};
+
+    for (const [key, value] of Object.entries(this.filter)) {
+      const columns = key.split(",");
+
+      if (typeof value === "string") {
+        const values = value.split(",");
+
+        if (columns.length > 1) {
+          where.OR = columns.map((col) => ({
+            [col]: { in: values },
+          }));
+        } else {
+          where[key] = values.length > 1 ? { in: values } : value;
+        }
+      } else if (typeof value === "object") {
+        // Nested operators (gt, gte, lt, lte, not, like)
+        const operatorConditions: Record<string, unknown> = {};
+
+        for (const [op, rawValue] of Object.entries(value)) {
+          let parsedValue: unknown = rawValue;
+
+          if (!Number.isNaN(Number(rawValue))) {
+            parsedValue = Number(rawValue);
+          } else if (!Number.isNaN(Date.parse(String(rawValue)))) {
+            parsedValue = new Date(String(rawValue));
+          }
+
+          switch (op) {
+            case "gt":
+            case "gte":
+            case "lt":
+            case "lte": {
+              operatorConditions[op] = parsedValue;
+              break;
+            }
+            case "not": {
+              operatorConditions.not = parsedValue;
+              break;
+            }
+            case "like": {
+              operatorConditions.contains = String(parsedValue);
+              break;
+            }
+          }
+        }
+
+        if (columns.length > 1) {
+          where.OR = columns.map((col) => ({
+            [col]: operatorConditions,
+          }));
+        } else {
+          where[key] = operatorConditions;
+        }
+      }
+    }
+    return where;
+  }
+
+  private buildSelect(): Record<string, boolean> | undefined {
+    if (this.select === undefined) {
+      return undefined;
+    }
+
+    return Object.fromEntries(this.select.map((field) => [field, true]));
+  }
+
+  private buildInclude(): Record<string, boolean> | undefined {
+    if (this.join === undefined) {
+      return undefined;
+    }
+
+    return Object.fromEntries(this.join.map((relation) => [relation, true]));
+  }
+
+  private buildSkip(): number | undefined {
+    if (this.page == null || this.perPage == null) {
+      return undefined;
+    }
+    return (this.page - 1) * this.perPage;
+  }
+
+  private buildTake(): number | undefined {
+    return this.perPage;
+  }
+
+  private buildOrderBy():
+    | Record<string, "asc" | "desc">
+    | Record<string, "asc" | "desc">[]
+    | undefined {
+    if (this.sort === undefined) {
+      return undefined;
+    }
+
+    if (typeof this.sort === "string") {
+      return { uuid: this.sort as "asc" | "desc" };
+    }
+
+    return Object.entries(this.sort).map(([field, order]) => ({
+      [field]: order,
+    }));
+  }
 }


### PR DESCRIPTION
Implementacja parametrów w query wg https://docs.google.com/document/d/1YpSIBLFYszVawgPltgy-5xatS3aux5rk5ywSWyL5D6o/edit?tab=t.5bi2xfky1rii

Na początku chciałem rozszerzyć prismę o dodatkową metodę do obsługi tylko tego, ale mi się nie udało, bo solvro config krzyczał za bardzo. Końcowo jest trochę bardziej rozszerzone DTO z opcją to konwersji na query prismowe, więc wszystko co trzeba zrobić to 
    return await this.prisma.event.findMany(query.toPrisma("Event"));

a jak chcemy dodać własne parametry to np
    return await this.prisma.event.findMany({...query.toPrisma("Event"), where:{...}});

ten przykładowy kontroler eventów jest całkowicie do przerobienia, ale tak sobie testowałem tylko czy działa. Na pewno zostały tesy tego, ale ja za godzinę wyjeżdżam na 2 tyg wakacji, więc nie będę miał czasu tego skończyć, a nie chcę was blokować, więc zapraszam do pomocy i dokończenia. 

