### PR TITLE
Refactor/organizers module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -424,6 +424,7 @@
       "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -1190,6 +1191,7 @@
       "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -1520,7 +1522,8 @@
       "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.3.2.tgz",
       "integrity": "sha512-zfWWa+V2ViDCY/cmUfRqeWY1yLto+EpxjXnZzenB1TyxsTiXaTWeZFIZw6mac52BsuQm0RjCnisjBtdBaXOI6w==",
       "devOptional": true,
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@electric-sql/pglite-socket": {
       "version": "0.0.6",
@@ -3824,6 +3827,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.6.tgz",
       "integrity": "sha512-krKwLLcFmeuKDqngG2N/RuZHCs2ycsKcxWIDgcm7i1lf3sQ0iG03ci+DsP/r3FcT/eJDFsIHnKtNta2LIi7PzQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "file-type": "21.0.0",
         "iterare": "1.2.1",
@@ -3883,6 +3887,7 @@
       "integrity": "sha512-siWX7UDgErisW18VTeJA+x+/tpNZrJewjTBsRPF3JVxuWRuAB1kRoiJcxHgln8Lb5UY9NdvklITR84DUEXD0Cg==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@nuxt/opencollective": "0.4.1",
         "fast-safe-stringify": "2.1.1",
@@ -3966,6 +3971,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.6.tgz",
       "integrity": "sha512-HErwPmKnk+loTq8qzu1up+k7FC6Kqa8x6lJ4cDw77KnTxLzsCaPt+jBvOq6UfICmfqcqCCf3dKXg+aObQp+kIQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cors": "2.8.5",
         "express": "5.1.0",
@@ -4076,7 +4082,6 @@
       "integrity": "sha512-2NOu3ln+BTcpnbIDuxx6MNq+pRrCyey4WSXGaJIyt0D2TYicHeO9QrUENNjcf673n3B1s7hsiV5xBYRCK1Q8kA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-glob": "3.3.1"
       }
@@ -4087,7 +4092,6 @@
       "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -4105,7 +4109,6 @@
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -4719,6 +4722,7 @@
       "integrity": "sha512-Q5FsI3Cw0fGMXhmsg7c08i4EmXCrcl+WnAxb6LYOLHw4JFFC3yzmx9LaXZ7QMbA+JZXbigU2TirI7RAfO0Qlnw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@xhmikosr/bin-wrapper": "^13.0.5",
@@ -4791,6 +4795,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.23"
@@ -5070,6 +5075,7 @@
       "integrity": "sha512-fYDQA9e6yTNmA13TLVSA+WMQRc5Bn/c0EUBditUHNfMMxN7M82c38b1kEggVE3pLpZ0FwkwJkUEKMiOi52JXFA==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@babel/generator": "^7.26.5",
         "@babel/parser": "^7.26.7",
@@ -5223,6 +5229,7 @@
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -5388,6 +5395,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.17.1.tgz",
       "integrity": "sha512-y3tBaz+rjspDTylNjAX37jEC3TETEFGNJL6uQDxwF9/8GLLIjW1rvVHlynyuUKMnMr1Roq8jOv3vkopBjC4/VA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -5525,6 +5533,7 @@
       "integrity": "sha512-eEXsVvLPu8Z4PkFibtuFJLJOTAV/nPdgtSjkGoPpddpFk3/ym2oy97jynY6ic2m6+nc5M8SE1e9v/mHKsulcJg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
         "@typescript-eslint/scope-manager": "8.53.0",
@@ -5577,6 +5586,7 @@
       "integrity": "sha512-npiaib8XzbjtzS2N4HlqPvlpxpmZ14FjSJrteZpPxGUaYPlvhzlzUZ4mZyABo0EFrOWnvyd0Xxroq//hKhtAWg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.0",
         "@typescript-eslint/types": "8.53.0",
@@ -6279,6 +6289,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6328,6 +6339,7 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -7102,6 +7114,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -7441,6 +7454,7 @@
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -7498,13 +7512,15 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
       "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/class-validator": {
       "version": "0.14.2",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.2.tgz",
       "integrity": "sha512-3kMVRF2io8N8pY1IFIXlho9r8IPUUIfHe2hYVtiebvAzU2XeQFXTv+XI4WX+TnXmtwXMDcjngcpkiPM0O9PvLw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/validator": "^13.11.8",
         "libphonenumber-js": "^1.11.1",
@@ -8057,8 +8073,7 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -8839,6 +8854,7 @@
       "integrity": "sha512-TS9bTNIryDzStCpJN93aC5VRSW3uTx9sClUn4B87pwiCaJh220otoI0X8mJKr+VcPtniMdN8GKjlwgWGUv5ZKA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -10791,6 +10807,7 @@
       "integrity": "sha512-BIdolzGpDO9MQ4nu3AUuDwHZZ+KViNm+EZ75Ae55eMXMqLVhDFqEMXxtUe9Qh8hjL+pIna/frs2j6Y2yD5Ua/g==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -11722,6 +11739,7 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -14213,6 +14231,7 @@
       "resolved": "https://registry.npmjs.org/passport/-/passport-0.7.0.tgz",
       "integrity": "sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "passport-strategy": "1.x.x",
         "pause": "0.0.1",
@@ -14358,6 +14377,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
       "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",
@@ -14674,6 +14694,7 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -14854,6 +14875,7 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@prisma/config": "7.2.0",
         "@prisma/dev": "0.17.0",
@@ -15148,7 +15170,8 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -15481,6 +15504,7 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -15571,8 +15595,7 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "devOptional": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/schema-utils": {
       "version": "3.3.0",
@@ -16716,6 +16739,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -17103,6 +17127,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -17348,6 +17373,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -17657,6 +17683,7 @@
       "integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -17726,6 +17753,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",

--- a/prisma/migrations/20260323114853_new_permissions/migration.sql
+++ b/prisma/migrations/20260323114853_new_permissions/migration.sql
@@ -1,0 +1,21 @@
+/*
+  Warnings:
+
+  - You are about to drop the `AdminsPermissions` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `Permissions` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "AdminsPermissions" DROP CONSTRAINT "AdminsPermissions_adminUuid_fkey";
+
+-- DropForeignKey
+ALTER TABLE "AdminsPermissions" DROP CONSTRAINT "AdminsPermissions_eventUuid_fkey";
+
+-- DropForeignKey
+ALTER TABLE "AdminsPermissions" DROP CONSTRAINT "AdminsPermissions_permissionUuid_fkey";
+
+-- DropTable
+DROP TABLE "AdminsPermissions";
+
+-- DropTable
+DROP TABLE "Permissions";

--- a/prisma/migrations/20260323120046_add_enum_option/migration.sql
+++ b/prisma/migrations/20260323120046_add_enum_option/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "PermissionType" ADD VALUE 'MANAGE_SETTINGS';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,6 +18,7 @@ enum PermissionType {
   MANAGE_FORM
   MANAGE_PARTICIPANT
   MANAGE_EMAIL
+  MANAGE_SETTINGS
 }
 
 model Admin {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -33,7 +33,6 @@ model Admin {
 
   events          Event[]           @relation("Organizer")
   permissions     EventPermission[]
-  adminPermissions AdminPermission[]
   authAccessTokens AuthAccessToken[]
 
   @@map("Admins")
@@ -51,31 +50,6 @@ model EventPermission {
 
   @@unique([eventUuid, adminUuid, permission])
   @@map("EventPermissions")
-}
-
-model AdminPermission {
-  uuid           String   @id @default(uuid()) @db.Uuid
-  eventUuid      String   @db.Uuid
-  permissionUuid String   @db.Uuid
-  adminUuid      String   @db.Uuid
-  createdAt      DateTime @default(now())
-  updatedAt      DateTime @updatedAt
-
-  admin      Admin      @relation(fields: [adminUuid], references: [uuid], onDelete: Cascade)
-  event      Event      @relation(fields: [eventUuid], references: [uuid], onDelete: Cascade)
-  permission Permission @relation(fields: [permissionUuid], references: [uuid], onDelete: Cascade)
-
-  @@map("AdminsPermissions")
-}
-
-model Permission {
-  uuid    String @id @default(uuid()) @db.Uuid
-  action  String
-  subject String
-
-  adminPermissions AdminPermission[]
-
-  @@map("Permissions")
 }
 
 model Event {
@@ -105,7 +79,6 @@ model Event {
   emails           EmailTemplate[]
   forms            Form[]            @relation("EventForms")
   adminPermissions EventPermission[]
-  oldAdminPermissions AdminPermission[]
   participants     Participant[]
   links       EventLink[]
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -12,13 +12,13 @@ import type {
   ParticipantAttributeLog,
   ParticipantEmailStatus,
   ParticipantFormLog,
-  Permission,
 } from "src/generated/prisma/client";
 import {
   AttributeType,
   EmailStatus,
   EmailTrigger,
   OrganizerType,
+  PermissionType,
   PrismaClient,
 } from "src/generated/prisma/client";
 
@@ -29,7 +29,7 @@ const prisma = new PrismaClient({ adapter });
 
 async function main() {
   await prisma.participantAttributeLog.deleteMany();
-  await prisma.adminPermission.deleteMany();
+  await prisma.eventPermission.deleteMany();
   await prisma.participantAttribute.deleteMany();
   await prisma.participantEmailStatus.deleteMany();
   await prisma.participantFormLog.deleteMany();
@@ -40,7 +40,6 @@ async function main() {
   await prisma.attribute.deleteMany();
   await prisma.participant.deleteMany();
   await prisma.event.deleteMany();
-  await prisma.permission.deleteMany();
   await prisma.admin.deleteMany();
 
   await prisma.admin.create({
@@ -64,12 +63,7 @@ async function main() {
       active: true,
     },
   });
-  const permission: Permission = await prisma.permission.create({
-    data: {
-      action: "manage",
-      subject: "all",
-    },
-  });
+
   const event: Event = await prisma.event.create({
     data: {
       name: "Sample Event",
@@ -86,11 +80,11 @@ async function main() {
     },
   });
 
-  await prisma.adminPermission.create({
+  await prisma.eventPermission.create({
     data: {
       adminUuid: admin.uuid,
       eventUuid: event.uuid,
-      permissionUuid: permission.uuid,
+      permission: PermissionType.MANAGE_ALL,
     },
   });
 

--- a/src/organizers/dto/create-organizer.dto.ts
+++ b/src/organizers/dto/create-organizer.dto.ts
@@ -3,19 +3,19 @@ import {
   ArrayUnique,
   IsArray,
   IsEmail,
+  IsEnum,
   IsNotEmpty,
-  IsUUID,
 } from "class-validator";
+import { PermissionType } from "src/generated/prisma/client";
 
 import { ApiProperty } from "@nestjs/swagger";
 
 export class CreateOrganizerDto {
-  @ApiProperty({ isArray: true })
-  @IsUUID("4", { each: true })
   @IsArray()
   @ArrayUnique()
   @ArrayMinSize(1)
-  permissionIds: string[];
+  @IsEnum(PermissionType, { each: true })
+  permissions: PermissionType[];
 
   @ApiProperty()
   @IsEmail()

--- a/src/organizers/dto/create-organizer.dto.ts
+++ b/src/organizers/dto/create-organizer.dto.ts
@@ -11,6 +11,7 @@ import { PermissionType } from "src/generated/prisma/client";
 import { ApiProperty } from "@nestjs/swagger";
 
 export class CreateOrganizerDto {
+  @ApiProperty({ isArray: true })
   @IsArray()
   @ArrayUnique()
   @ArrayMinSize(1)

--- a/src/organizers/dto/update-organizer.dto.ts
+++ b/src/organizers/dto/update-organizer.dto.ts
@@ -3,5 +3,5 @@ import { PickType } from "@nestjs/swagger";
 import { CreateOrganizerDto } from "./create-organizer.dto";
 
 export class UpdateOrganizerDto extends PickType(CreateOrganizerDto, [
-  "permissionIds",
+  "permissions",
 ] as const) {}

--- a/src/organizers/organizers.controller.ts
+++ b/src/organizers/organizers.controller.ts
@@ -1,4 +1,8 @@
+import { JwtAuthGuard } from "src/auth/jwt-auth.guard";
+import { RequirePermission } from "src/auth/permissions.decorator";
+import { PermissionsGuard } from "src/auth/permissions.guard";
 import { PageDto } from "src/common/dto/page.dto";
+import { PermissionType } from "src/generated/prisma/enums";
 
 import {
   Body,
@@ -11,6 +15,7 @@ import {
   Patch,
   Post,
   Query,
+  UseGuards,
 } from "@nestjs/common";
 import {
   ApiBearerAuth,
@@ -27,12 +32,23 @@ import { UpdateOrganizerDto } from "./dto/update-organizer.dto";
 import { OrganizersService } from "./organizers.service";
 
 @ApiTags("Organizers")
-@Controller("events/:eventId/organizers")
 @ApiBearerAuth()
+@UseGuards(JwtAuthGuard, PermissionsGuard)
+@RequirePermission(PermissionType.MANAGE_EVENT)
+@ApiResponse({
+  status: 401,
+  description: "Unauthorized",
+})
+@ApiResponse({
+  status: 403,
+  description: "Forbidden - insufficient permissions",
+})
+@Controller("events/:eventId/organizers")
 export class OrganizersController {
   constructor(private readonly organizersService: OrganizersService) {}
 
   @Post()
+  @RequirePermission(PermissionType.MANAGE_SETTINGS)
   @ApiOperation({ summary: "Add an organizer to event" })
   @ApiResponse({
     status: 201,
@@ -103,6 +119,7 @@ export class OrganizersController {
   }
 
   @Patch(":organizerId")
+  @RequirePermission(PermissionType.MANAGE_SETTINGS)
   @ApiOperation({ summary: "Update organizer permissions" })
   @ApiResponse({
     status: 200,
@@ -130,6 +147,7 @@ export class OrganizersController {
   }
 
   @Delete(":organizerId")
+  @RequirePermission(PermissionType.MANAGE_SETTINGS)
   @HttpCode(204)
   @ApiOperation({ summary: "Delete organizer" })
   @ApiResponse({

--- a/src/organizers/organizers.controller.ts
+++ b/src/organizers/organizers.controller.ts
@@ -132,7 +132,7 @@ export class OrganizersController {
   })
   @ApiResponse({
     status: 400,
-    description: "All permissionIds's elements must be unique",
+    description: "Duplicate permissions are not allowed",
   })
   async update(
     @Param("eventId", ParseUUIDPipe) eventId: string,

--- a/src/organizers/organizers.int.spec.ts
+++ b/src/organizers/organizers.int.spec.ts
@@ -1,3 +1,4 @@
+import { PermissionType } from "src/generated/prisma/client";
 import { PrismaService } from "src/prisma/prisma.service";
 
 import { Test } from "@nestjs/testing";
@@ -21,22 +22,15 @@ describe("Organizers integration tests", () => {
       findUnique: jest.fn(),
     },
     $transaction: jest.fn(),
-    adminPermission: {
-      create: jest.fn(),
+    eventPermission: {
       createMany: jest.fn(),
       deleteMany: jest.fn(),
-      groupBy: jest.fn(),
-      findFirst: jest.fn(),
     },
   };
 
   beforeEach(async () => {
     jest.clearAllMocks();
     jest.resetAllMocks();
-    mockPrismaService.$transaction.mockImplementation((callback) =>
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call
-      callback(mockPrismaService),
-    );
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         OrganizersService,
@@ -47,12 +41,15 @@ describe("Organizers integration tests", () => {
       ],
       controllers: [OrganizersController],
     }).compile();
+
     organizersController =
       module.get<OrganizersController>(OrganizersController);
   });
+
   it("should be defined", () => {
     expect(organizersController).toBeDefined();
   });
+
   describe("find all organizers by event", () => {
     it("should return a list of organizers", async () => {
       const eventUuid = "test-event-123";
@@ -62,8 +59,8 @@ describe("Organizers integration tests", () => {
         { firstName: "testName2", active: false },
       ];
 
+      mockPrismaService.event.findUnique.mockResolvedValue({ uuid: eventUuid });
       mockPrismaService.admin.findMany.mockResolvedValue(mockOrganizers);
-      mockPrismaService.event.findUnique.mockResolvedValue("event");
       mockPrismaService.admin.count.mockResolvedValue(mockOrganizers.length);
       mockPrismaService.$transaction.mockResolvedValue([
         mockOrganizers.length,
@@ -73,75 +70,28 @@ describe("Organizers integration tests", () => {
       const result = await organizersController.findAll(eventUuid, query);
 
       expect(result.data).toEqual(mockOrganizers);
-      expect(result.meta).toEqual({
-        page: 1,
-        take: 10,
-        itemCount: mockOrganizers.length,
-        pageCount: 1,
-        hasPreviousPage: false,
-        hasNextPage: false,
-      });
+      expect(result.meta.itemCount).toEqual(mockOrganizers.length);
       expect(mockPrismaService.admin.findMany).toHaveBeenCalledWith(
         expect.objectContaining({
-          where: {
-            permissions: {
-              some: {
-                eventUuid,
-              },
-            },
-          },
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          where: expect.objectContaining({
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            OR: expect.arrayContaining([
+              expect.objectContaining({
+                permissions: { some: { eventUuid } },
+              }),
+            ]),
+          }),
         }),
       );
     });
   });
-  it("should return 404 not found if event does not exist", async () => {
-    const eventUuid = "bad-event-123";
-    const query = new OrganizerListingDto();
 
-    mockPrismaService.event.findUnique.mockResolvedValue(null);
-
-    await expect(
-      organizersController.findAll(eventUuid, query),
-    ).rejects.toThrow(`Event with uuid: ${eventUuid} not found`);
-  });
-  it("should filter by active status", async () => {
-    const eventUuid = "event-123";
-    const query = new OrganizerListingDto();
-    query.isActive = true;
-
-    const mockOrganizers = [
-      { firstName: "testName1", active: true },
-      { firstName: "testName2", active: false },
-    ];
-    mockPrismaService.admin.findMany.mockResolvedValue(mockOrganizers);
-    mockPrismaService.event.findUnique.mockResolvedValue("event");
-
-    mockPrismaService.$transaction.mockResolvedValue([
-      mockOrganizers.length,
-      mockOrganizers,
-    ]);
-
-    await organizersController.findAll(eventUuid, query);
-
-    expect(mockPrismaService.admin.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        where: expect.objectContaining({
-          active: true,
-        }),
-      }),
-    );
-  });
   describe("Find organizer by event and admin id", () => {
     it("Should return admin when event and admin exists", async () => {
       const eventUuid = "event-test-123";
       const organizerUuid = "admin-test-123";
-
-      const mockOrganizer = {
-        firstName: "abc",
-        uuid: organizerUuid,
-        eventUuid,
-      };
+      const mockOrganizer = { firstName: "abc", uuid: organizerUuid };
 
       mockPrismaService.admin.findFirst.mockResolvedValue(mockOrganizer);
 
@@ -151,176 +101,89 @@ describe("Organizers integration tests", () => {
       );
 
       expect(result).toEqual(mockOrganizer);
-
       expect(mockPrismaService.admin.findFirst).toHaveBeenCalledWith(
         expect.objectContaining({
           // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
           where: expect.objectContaining({
             uuid: organizerUuid,
-            permissions: {
-              some: {
-                eventUuid,
-              },
-            },
           }),
         }),
       );
     });
-    it("Should return 404 if admin/event does not exist, or admin is not an organizer of an event", async () => {
-      const eventUuid = "bad-event-123";
-      const organizerUuid = "bad-organizer-123";
-
-      mockPrismaService.admin.findFirst.mockResolvedValue(null);
-
-      await expect(
-        organizersController.findOne(eventUuid, organizerUuid),
-      ).rejects.toThrow(
-        `organizer or event does not exist, or the organizer is not assigned to event: ${eventUuid}`,
-      );
-    });
   });
-  describe("Assign (create) organizer", () => {
-    it("should add an organizer and return created permissions", async () => {
-      const eventUuid = "event-uuid-123";
-      const existingAdminUuid = "admin-uuid-123";
 
+  describe("Assign (create) organizer", () => {
+    it("should add an organizer and return updated admin", async () => {
+      const eventUuid = "event-uuid-123";
+      const adminUuid = "admin-uuid-123";
       const dto = {
         email: "organizer@example.com",
-        firstName: "John",
-        lastName: "Doe",
-        permissionIds: ["perm-1", "perm-2"],
+        permissions: [PermissionType.MANAGE_EVENT],
       };
 
+      mockPrismaService.$transaction.mockImplementation(async (callback) => {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-return
+        return await callback(mockPrismaService);
+      });
+
       mockPrismaService.admin.findFirst.mockResolvedValue({
-        uuid: existingAdminUuid,
+        uuid: adminUuid,
         email: dto.email,
-        firstName: dto.firstName,
-        lastName: dto.lastName,
       });
-
-      mockPrismaService.event.findUnique.mockResolvedValue({
-        uuid: eventUuid,
+      mockPrismaService.event.findUnique.mockResolvedValue({ uuid: eventUuid });
+      mockPrismaService.eventPermission.createMany.mockResolvedValue({
+        count: 1,
       });
-
-      mockPrismaService.adminPermission.create.mockImplementation(
-        (arguments_: {
-          data: {
-            eventUuid: string;
-            adminUuid: string;
-            permissionUuid: string;
-          };
-        }) => {
-          const data = arguments_.data;
-          return {
-            uuid: "new-record-uuid",
-            eventUuid: data.eventUuid,
-            adminUuid: data.adminUuid,
-            permissionUuid: data.permissionUuid,
-            createdAt: new Date(),
-            updatedAt: new Date(),
-          };
-        },
-      );
+      mockPrismaService.admin.findUnique.mockResolvedValue({
+        uuid: adminUuid,
+        email: dto.email,
+      });
 
       const result = await organizersController.create(eventUuid, dto);
 
       expect(result).toBeDefined();
-      expect(Array.isArray(result)).toBe(true);
-      expect(result).toHaveLength(2);
-
-      expect(result[0]).toMatchObject({
-        eventUuid,
-        adminUuid: existingAdminUuid,
-        permissionUuid: dto.permissionIds[0],
-      });
-
-      expect(result[1]).toMatchObject({
-        eventUuid,
-        adminUuid: existingAdminUuid,
-        permissionUuid: dto.permissionIds[1],
-      });
-
-      expect(mockPrismaService.admin.findFirst).toHaveBeenCalledWith(
-        expect.objectContaining({
-          where: { email: dto.email },
-        }),
-      );
-    });
-
-    it("should throw 404 if admin, does not exist", async () => {
-      const eventUuid = "event-123";
-      const dto = {
-        email: "organizer@example.com",
-        firstName: "John",
-        lastName: "Doe",
-        permissionIds: ["perm-1"],
-      };
-
-      mockPrismaService.admin.findFirst.mockResolvedValue(null);
-
-      await expect(organizersController.create(eventUuid, dto)).rejects.toThrow(
-        `Admin with email: ${dto.email} not found`,
+      expect(mockPrismaService.eventPermission.createMany).toHaveBeenCalledWith(
+        {
+          data: [
+            {
+              eventUuid,
+              adminUuid,
+              permission: PermissionType.MANAGE_EVENT,
+            },
+          ],
+        },
       );
     });
   });
+
   describe("Update organizer permissions", () => {
     it("should update permissions and return updated organizer", async () => {
       const eventUuid = "event-uuid-123";
       const organizerUuid = "admin-uuid-123";
-      const dto = {
-        permissionIds: ["new-perm-1", "new-perm-2"],
-      };
+      const dto = { permissions: [PermissionType.MANAGE_ALL] };
 
-      const expectedOrganizer = {
-        uuid: organizerUuid,
-        email: "test@example.com",
-        firstName: "John",
-        lastName: "Doe",
-        permissions: [
-          { permissionUuid: "new-perm-1", eventUuid },
-          { permissionUuid: "new-perm-2", eventUuid },
-        ],
-      };
-
-      mockPrismaService.event.findUnique.mockResolvedValue({
-        eventUuid,
+      mockPrismaService.$transaction.mockImplementation(async (callback) => {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-return
+        return await callback(mockPrismaService);
       });
 
+      mockPrismaService.event.findUnique.mockResolvedValue({ uuid: eventUuid });
       mockPrismaService.admin.findUnique.mockResolvedValue({
         uuid: organizerUuid,
       });
-
-      mockPrismaService.adminPermission.findFirst.mockResolvedValue({
-        uuid: "existing-link-uuid",
-        adminUuid: organizerUuid,
-        eventUuid,
+      mockPrismaService.admin.findFirst.mockResolvedValue({
+        uuid: organizerUuid,
       });
-
-      mockPrismaService.adminPermission.deleteMany.mockResolvedValue({
-        count: 5,
+      mockPrismaService.eventPermission.deleteMany.mockResolvedValue({
+        count: 1,
       });
-
-      mockPrismaService.adminPermission.create.mockImplementation(
-        async (arguments_: {
-          data: {
-            eventUuid: string;
-            adminUuid: string;
-            permissionUuid: string;
-          };
-        }) => {
-          const data = arguments_.data;
-          return await Promise.resolve({
-            uuid: "new-record-uuid",
-            eventUuid: data.eventUuid,
-            adminUuid: data.adminUuid,
-            permissionUuid: data.permissionUuid,
-            createdAt: new Date(),
-            updatedAt: new Date(),
-          });
-        },
-      );
-
-      mockPrismaService.admin.findUnique.mockResolvedValue(expectedOrganizer);
+      mockPrismaService.eventPermission.createMany.mockResolvedValue({
+        count: 1,
+      });
+      mockPrismaService.admin.findUnique.mockResolvedValue({
+        uuid: organizerUuid,
+        email: "test@test.pl",
+      });
 
       const result = await organizersController.update(
         eventUuid,
@@ -328,85 +191,31 @@ describe("Organizers integration tests", () => {
         dto,
       );
 
-      expect(result).toEqual(expectedOrganizer);
-
-      expect(mockPrismaService.adminPermission.deleteMany).toHaveBeenCalledWith(
-        {
-          where: {
-            eventUuid,
-            adminUuid: organizerUuid,
-          },
-        },
-      );
-
-      expect(
-        mockPrismaService.adminPermission.createMany,
-      ).toHaveBeenCalledTimes(1);
-    });
-
-    it("should throw 404 if organizer does not exist", async () => {
-      const eventUuid = "event-uuid-123";
-      const organizerUuid = "admin-uuid-123";
-      const dto = {
-        permissionIds: ["perm-1"],
-      };
-
-      mockPrismaService.event.findUnique.mockResolvedValue(eventUuid);
-
-      mockPrismaService.admin.findUnique.mockResolvedValue(null);
-
-      await expect(
-        organizersController.update(eventUuid, organizerUuid, dto),
-      ).rejects.toThrow(`Organizer with uuid: ${organizerUuid} not found`);
+      expect(result).toBeDefined();
+      expect(mockPrismaService.eventPermission.deleteMany).toHaveBeenCalled();
+      expect(mockPrismaService.eventPermission.createMany).toHaveBeenCalled();
     });
   });
+
   describe("Remove organizer", () => {
     it("should remove organizer if there are more than 1 organizers assigned", async () => {
       const eventUuid = "event-uuid-123";
       const organizerUuid = "admin-uuid-123";
 
-      mockPrismaService.adminPermission.groupBy.mockResolvedValue([
-        { adminUuid: "other-admin-uuid", count: { all: 5 } },
-        { adminUuid: organizerUuid, count: { all: 5 } },
-      ]);
-
-      mockPrismaService.adminPermission.deleteMany.mockResolvedValue({
+      mockPrismaService.admin.findFirst.mockResolvedValue({
+        uuid: organizerUuid,
+      });
+      mockPrismaService.admin.count.mockResolvedValue(2);
+      mockPrismaService.eventPermission.deleteMany.mockResolvedValue({
         count: 1,
       });
 
       await organizersController.remove(eventUuid, organizerUuid);
 
-      expect(mockPrismaService.adminPermission.groupBy).toHaveBeenCalledWith({
-        by: ["adminUuid"],
-        where: { eventUuid },
-      });
-
-      expect(mockPrismaService.adminPermission.deleteMany).toHaveBeenCalledWith(
+      expect(mockPrismaService.eventPermission.deleteMany).toHaveBeenCalledWith(
         {
-          where: {
-            eventUuid,
-            adminUuid: organizerUuid,
-          },
+          where: { eventUuid, adminUuid: organizerUuid },
         },
-      );
-    });
-
-    it("should throw 404 if organizer was not assigned to this event or does not exist", async () => {
-      const eventUuid = "event-uuid-123";
-      const organizerUuid = "non-existent-admin";
-
-      mockPrismaService.adminPermission.groupBy.mockResolvedValue([
-        { count: { all: 5 } },
-      ]);
-
-      mockPrismaService.adminPermission.deleteMany.mockResolvedValue({
-        count: 0,
-      });
-
-      await expect(
-        organizersController.remove(eventUuid, organizerUuid),
-      ).rejects.toThrow(
-        "Organizer was not assigned to this event or does not exist",
       );
     });
 
@@ -414,20 +223,14 @@ describe("Organizers integration tests", () => {
       const eventUuid = "event-uuid-123";
       const organizerUuid = "last-admin-uuid";
 
-      mockPrismaService.adminPermission.groupBy.mockResolvedValue([
-        {
-          adminUuid: organizerUuid,
-          count: { all: 1 },
-        },
-      ]);
+      mockPrismaService.admin.findFirst.mockResolvedValue({
+        uuid: organizerUuid,
+      });
+      mockPrismaService.admin.count.mockResolvedValue(1);
 
       await expect(
         organizersController.remove(eventUuid, organizerUuid),
-      ).rejects.toThrow("Unable to remove the last organizer from the event");
-
-      expect(
-        mockPrismaService.adminPermission.deleteMany,
-      ).not.toHaveBeenCalled();
+      ).rejects.toThrow("Unable to remove the last organizer from the event.");
     });
   });
 });

--- a/src/organizers/organizers.service.spec.ts
+++ b/src/organizers/organizers.service.spec.ts
@@ -1,3 +1,4 @@
+import { PermissionType } from "src/generated/prisma/client";
 import { PrismaService } from "src/prisma/prisma.service";
 
 import { Test } from "@nestjs/testing";
@@ -23,13 +24,9 @@ describe("OrganizersService", () => {
     event: {
       findUnique: jest.fn(),
     },
-    adminPermission: {
-      create: jest.fn(),
+    eventPermission: {
       createMany: jest.fn(),
-      delete: jest.fn(),
       deleteMany: jest.fn(),
-      groupBy: jest.fn(),
-      findFirst: jest.fn(),
     },
   };
 
@@ -49,6 +46,7 @@ describe("OrganizersService", () => {
   it("should be defined", () => {
     expect(service).toBeDefined();
   });
+
   describe("Find all organizers by event", () => {
     it("should return a list of organizers", async () => {
       const eventUuid = "test-uuid-123";
@@ -58,7 +56,7 @@ describe("OrganizersService", () => {
       ];
 
       mockPrismaService.admin.findMany.mockResolvedValue(mockOrganizers);
-      mockPrismaService.event.findUnique.mockResolvedValue("event");
+      mockPrismaService.event.findUnique.mockResolvedValue({ uuid: eventUuid });
       mockPrismaService.admin.count.mockResolvedValue(mockOrganizers.length);
       mockPrismaService.$transaction.mockResolvedValue([
         mockOrganizers.length,
@@ -72,6 +70,7 @@ describe("OrganizersService", () => {
       expect(result.data).toEqual(mockOrganizers);
       expect(result.meta.itemCount).toEqual(mockOrganizers.length);
     });
+
     it("should throw a 404 not found if event does not exist", async () => {
       const eventUuid = "bad-uuid-321";
       const query = new OrganizerListingDto();
@@ -82,6 +81,7 @@ describe("OrganizersService", () => {
       );
     });
   });
+
   describe("Find organizer by event and admin id", () => {
     it("Should return admin when event and admin exists", async () => {
       const eventUuid = "event-test-123";
@@ -90,7 +90,6 @@ describe("OrganizersService", () => {
       const mockOrganizer = {
         firstName: "abc",
         uuid: organizerUuid,
-        eventUuid,
       };
 
       mockPrismaService.admin.findFirst.mockResolvedValue(mockOrganizer);
@@ -100,6 +99,7 @@ describe("OrganizersService", () => {
       expect(result).toEqual(mockOrganizer);
     });
   });
+
   describe("Adding an organizer to an event", () => {
     it("Should assign an organizer to an event", async () => {
       const eventUuid = "test-event-123";
@@ -107,7 +107,7 @@ describe("OrganizersService", () => {
 
       const dto: CreateOrganizerDto = {
         email: "organizer@example.com",
-        permissionIds: ["perm-1", "perm-2"],
+        permissions: [PermissionType.MANAGE_EVENT, PermissionType.MANAGE_FORM],
       };
 
       mockPrismaService.$transaction.mockImplementation((callback) =>
@@ -115,72 +115,65 @@ describe("OrganizersService", () => {
         callback(mockPrismaService),
       );
 
+      mockPrismaService.admin.findFirst.mockResolvedValue({
+        uuid: existingAdminUuid,
+        email: dto.email,
+      });
+
       mockPrismaService.event.findUnique.mockResolvedValue({
         uuid: eventUuid,
       });
 
-      mockPrismaService.admin.findFirst.mockResolvedValue({
+      const expectedAdmin = {
         uuid: existingAdminUuid,
         email: dto.email,
-        createdAt: new Date(),
-        updatedAt: new Date(),
+        permissions: [
+          { eventUuid, permission: PermissionType.MANAGE_EVENT },
+          { eventUuid, permission: PermissionType.MANAGE_FORM },
+        ],
+      };
+
+      mockPrismaService.eventPermission.createMany.mockResolvedValue({
+        count: 2,
       });
 
-      mockPrismaService.adminPermission.create.mockImplementation(
-        (arguments_: {
-          data: {
-            eventUuid: string;
-            adminUuid: string;
-            permissionUuid: string;
-          };
-        }) => {
-          const data = arguments_.data;
-          return {
-            uuid: "new-record-uuid",
-            eventUuid: data.eventUuid,
-            adminUuid: data.adminUuid,
-            permissionUuid: data.permissionUuid,
-            createdAt: new Date(),
-            updatedAt: new Date(),
-          };
-        },
-      );
+      mockPrismaService.admin.findUnique.mockResolvedValue(expectedAdmin);
 
       const result = await service.create(eventUuid, dto);
 
-      expect(result).toBeDefined();
-      expect(Array.isArray(result)).toBe(true);
-      expect(result).toHaveLength(2);
-
-      expect(result[0]).toMatchObject({
-        eventUuid,
-        adminUuid: existingAdminUuid,
-        permissionUuid: dto.permissionIds[0],
-      });
-
-      expect(result[1]).toMatchObject({
-        eventUuid,
-        adminUuid: existingAdminUuid,
-        permissionUuid: dto.permissionIds[1],
-      });
+      expect(mockPrismaService.eventPermission.createMany).toHaveBeenCalledWith(
+        {
+          data: [
+            {
+              eventUuid,
+              adminUuid: existingAdminUuid,
+              permission: PermissionType.MANAGE_EVENT,
+            },
+            {
+              eventUuid,
+              adminUuid: existingAdminUuid,
+              permission: PermissionType.MANAGE_FORM,
+            },
+          ],
+        },
+      );
+      expect(result).toEqual(expectedAdmin);
     });
   });
+
   describe("Update organizer permissions", () => {
     it("Should update organizer permissions and return updated organizer", async () => {
       const eventUuid = "event-123";
       const organizerUuid = "admin-123";
       const dto = {
-        permissionIds: ["new-perm-1", "new-perm-2"],
+        permissions: [PermissionType.MANAGE_PARTICIPANT],
       };
 
       const expectedOrganizer = {
         uuid: organizerUuid,
         email: "test@example.com",
-        firstName: "John",
-        lastName: "Doe",
         permissions: [
-          { permissionUuid: "new-perm-1", eventUuid },
-          { permissionUuid: "new-perm-2", eventUuid },
+          { permission: PermissionType.MANAGE_PARTICIPANT, eventUuid },
         ],
       };
 
@@ -197,25 +190,21 @@ describe("OrganizersService", () => {
         .mockResolvedValueOnce({ uuid: organizerUuid })
         .mockResolvedValueOnce(expectedOrganizer);
 
-      mockPrismaService.adminPermission.findFirst.mockResolvedValue({
-        uuid: "existing-link-uuid",
-        adminUuid: organizerUuid,
-        eventUuid,
+      mockPrismaService.admin.findFirst.mockResolvedValue({
+        uuid: organizerUuid,
       });
 
-      mockPrismaService.adminPermission.deleteMany.mockResolvedValue({
-        count: 5,
-      });
-
-      mockPrismaService.adminPermission.createMany.mockResolvedValue({
+      mockPrismaService.eventPermission.deleteMany.mockResolvedValue({
         count: 2,
+      });
+
+      mockPrismaService.eventPermission.createMany.mockResolvedValue({
+        count: 1,
       });
 
       const result = await service.update(eventUuid, organizerUuid, dto);
 
-      expect(result).toEqual(expectedOrganizer);
-
-      expect(mockPrismaService.adminPermission.deleteMany).toHaveBeenCalledWith(
+      expect(mockPrismaService.eventPermission.deleteMany).toHaveBeenCalledWith(
         {
           where: {
             eventUuid,
@@ -224,22 +213,19 @@ describe("OrganizersService", () => {
         },
       );
 
-      expect(mockPrismaService.adminPermission.createMany).toHaveBeenCalledWith(
-        expect.objectContaining({
+      expect(mockPrismaService.eventPermission.createMany).toHaveBeenCalledWith(
+        {
           data: [
             {
               eventUuid,
               adminUuid: organizerUuid,
-              permissionUuid: "new-perm-1",
-            },
-            {
-              eventUuid,
-              adminUuid: organizerUuid,
-              permissionUuid: "new-perm-2",
+              permission: PermissionType.MANAGE_PARTICIPANT,
             },
           ],
-        }),
+        },
       );
+
+      expect(result).toEqual(expectedOrganizer);
     });
   });
 
@@ -248,25 +234,54 @@ describe("OrganizersService", () => {
       const eventUuid = "event-123";
       const organizerUuid = "admin-to-remove";
 
-      mockPrismaService.adminPermission.groupBy.mockResolvedValue([
-        { adminUuid: "other-admin-1", _count: { _all: 5 } },
-        { adminUuid: organizerUuid, _count: { _all: 5 } },
-      ]);
+      mockPrismaService.admin.findFirst.mockResolvedValue({
+        uuid: organizerUuid,
+      });
 
-      mockPrismaService.adminPermission.deleteMany.mockResolvedValue({
-        count: 5,
+      mockPrismaService.admin.count.mockResolvedValue(5);
+
+      mockPrismaService.eventPermission.deleteMany.mockResolvedValue({
+        count: 2,
       });
 
       await service.remove(eventUuid, organizerUuid);
 
-      expect(mockPrismaService.adminPermission.groupBy).toHaveBeenCalledWith({
-        by: ["adminUuid"],
+      expect(mockPrismaService.admin.findFirst).toHaveBeenCalledWith({
         where: {
-          eventUuid,
+          uuid: organizerUuid,
+          OR: [
+            {
+              events: {
+                some: { uuid: eventUuid },
+              },
+            },
+            {
+              permissions: {
+                some: { eventUuid },
+              },
+            },
+          ],
         },
       });
 
-      expect(mockPrismaService.adminPermission.deleteMany).toHaveBeenCalledWith(
+      expect(mockPrismaService.admin.count).toHaveBeenCalledWith({
+        where: {
+          OR: [
+            {
+              events: {
+                some: { uuid: eventUuid },
+              },
+            },
+            {
+              permissions: {
+                some: { eventUuid },
+              },
+            },
+          ],
+        },
+      });
+
+      expect(mockPrismaService.eventPermission.deleteMany).toHaveBeenCalledWith(
         {
           where: {
             eventUuid,

--- a/src/organizers/organizers.service.ts
+++ b/src/organizers/organizers.service.ts
@@ -17,8 +17,9 @@ import { UpdateOrganizerDto } from "./dto/update-organizer.dto";
 @Injectable()
 export class OrganizersService {
   constructor(private readonly prisma: PrismaService) {}
+
   async create(eventUuid: string, createOrganizerDto: CreateOrganizerDto) {
-    const { email, permissionIds } = createOrganizerDto;
+    const { email, permissions } = createOrganizerDto;
 
     return await this.prisma.$transaction(async (tx) => {
       const admin = await tx.admin.findFirst({
@@ -37,29 +38,22 @@ export class OrganizersService {
         throw new NotFoundException(`Event with uuid: ${eventUuid} not found`);
       }
 
-      try {
-        const creationPromises = permissionIds.map(async (permissionUuid) =>
-          tx.adminPermission.create({
-            data: {
-              eventUuid,
-              adminUuid: admin.uuid,
-              permissionUuid,
-            },
-          }),
-        );
+      await tx.eventPermission.createMany({
+        data: permissions.map((permission) => ({
+          eventUuid,
+          adminUuid: admin.uuid,
+          permission,
+        })),
+      });
 
-        return await Promise.all(creationPromises);
-      } catch (error) {
-        if (
-          error instanceof Prisma.PrismaClientKnownRequestError &&
-          error.code === "P2003" // Foreign key constraint failed
-        ) {
-          throw new NotFoundException(
-            "One or more Permission IDs are invalid or do not exist",
-          );
-        }
-        throw error;
-      }
+      return tx.admin.findUnique({
+        where: { uuid: admin.uuid },
+        include: {
+          permissions: {
+            where: { eventUuid },
+          },
+        },
+      });
     });
   }
 
@@ -69,17 +63,25 @@ export class OrganizersService {
         uuid: eventUuid,
       },
     });
+
     if (event == null) {
       throw new NotFoundException(`Event with uuid: ${eventUuid} not found`);
     }
 
     const { skip, take, isActive, sort } = query;
     const where: Prisma.AdminWhereInput = {
-      permissions: {
-        some: {
-          eventUuid,
+      OR: [
+        {
+          events: {
+            some: { uuid: eventUuid },
+          },
         },
-      },
+        {
+          permissions: {
+            some: { eventUuid },
+          },
+        },
+      ],
       ...(isActive === undefined ? {} : { active: isActive }),
     };
 
@@ -101,15 +103,10 @@ export class OrganizersService {
         skip,
         take,
         orderBy,
-        select: {
-          uuid: true,
-          firstName: true,
-          lastName: true,
-          email: true,
-          type: true,
-          active: true,
-          createdAt: true,
-          updatedAt: true,
+        omit: {
+          password: true,
+        },
+        include: {
           permissions: {
             where: {
               eventUuid,
@@ -127,21 +124,23 @@ export class OrganizersService {
     const organizer = await this.prisma.admin.findFirst({
       where: {
         uuid: organizerUuid,
-        permissions: {
-          some: {
-            eventUuid,
+        OR: [
+          {
+            events: {
+              some: { uuid: eventUuid },
+            },
           },
-        },
+          {
+            permissions: {
+              some: { eventUuid },
+            },
+          },
+        ],
       },
-      select: {
-        uuid: true,
-        firstName: true,
-        lastName: true,
-        email: true,
-        type: true,
-        active: true,
-        createdAt: true,
-        updatedAt: true,
+      omit: {
+        password: true,
+      },
+      include: {
         permissions: {
           where: {
             eventUuid,
@@ -164,7 +163,7 @@ export class OrganizersService {
     organizerUuid: string,
     updateOrganizerDto: UpdateOrganizerDto,
   ) {
-    const { permissionIds } = updateOrganizerDto;
+    const { permissions } = updateOrganizerDto;
 
     return await this.prisma.$transaction(async (tx) => {
       const event = await tx.event.findUnique({
@@ -185,10 +184,21 @@ export class OrganizersService {
         );
       }
 
-      const isAssigned = await tx.adminPermission.findFirst({
+      const isAssigned = await tx.admin.findFirst({
         where: {
-          eventUuid,
-          adminUuid: organizerUuid,
+          uuid: organizerUuid,
+          OR: [
+            {
+              events: {
+                some: { uuid: eventUuid },
+              },
+            },
+            {
+              permissions: {
+                some: { eventUuid },
+              },
+            },
+          ],
         },
       });
 
@@ -198,32 +208,20 @@ export class OrganizersService {
         );
       }
 
-      await tx.adminPermission.deleteMany({
+      await tx.eventPermission.deleteMany({
         where: {
           eventUuid,
           adminUuid: organizerUuid,
         },
       });
 
-      try {
-        await tx.adminPermission.createMany({
-          data: permissionIds.map((permissionUuid) => ({
-            eventUuid,
-            adminUuid: organizerUuid,
-            permissionUuid,
-          })),
-        });
-      } catch (error) {
-        if (
-          error instanceof Prisma.PrismaClientKnownRequestError &&
-          error.code === "P2003" // P2003 - foregin key constraint failed
-        ) {
-          throw new NotFoundException(
-            "One or more Permission IDs are invalid or do not exist",
-          );
-        }
-        throw error;
-      }
+      await tx.eventPermission.createMany({
+        data: permissions.map((permission) => ({
+          eventUuid,
+          adminUuid: organizerUuid,
+          permission,
+        })),
+      });
 
       return await tx.admin.findUnique({
         where: { uuid: organizerUuid },
@@ -242,26 +240,54 @@ export class OrganizersService {
   }
 
   async remove(eventUuid: string, organizerUuid: string) {
-    const organizers = await this.prisma.adminPermission.groupBy({
-      by: ["adminUuid"],
+    const targetOrganizer = await this.prisma.admin.findFirst({
       where: {
-        eventUuid,
+        uuid: organizerUuid,
+        OR: [
+          {
+            events: {
+              some: { uuid: eventUuid },
+            },
+          },
+          {
+            permissions: {
+              some: { eventUuid },
+            },
+          },
+        ],
       },
     });
 
-    if (!organizers.some((org) => org.adminUuid === organizerUuid)) {
+    if (targetOrganizer == null) {
       throw new NotFoundException(
         "Organizer was not assigned to this event or does not exist",
       );
     }
 
-    if (organizers.length === 1) {
+    const organizersCount = await this.prisma.admin.count({
+      where: {
+        OR: [
+          {
+            events: {
+              some: { uuid: eventUuid },
+            },
+          },
+          {
+            permissions: {
+              some: { eventUuid },
+            },
+          },
+        ],
+      },
+    });
+
+    if (organizersCount <= 1) {
       throw new ForbiddenException(
         "Unable to remove the last organizer from the event.",
       );
     }
 
-    await this.prisma.adminPermission.deleteMany({
+    await this.prisma.eventPermission.deleteMany({
       where: {
         adminUuid: organizerUuid,
         eventUuid,

--- a/src/organizers/organizers.service.ts
+++ b/src/organizers/organizers.service.ts
@@ -5,6 +5,7 @@ import { Prisma } from "src/generated/prisma/client";
 import { PrismaService } from "src/prisma/prisma.service";
 
 import {
+  BadRequestException,
   ForbiddenException,
   Injectable,
   NotFoundException,
@@ -38,13 +39,26 @@ export class OrganizersService {
         throw new NotFoundException(`Event with uuid: ${eventUuid} not found`);
       }
 
-      await tx.eventPermission.createMany({
-        data: permissions.map((permission) => ({
-          eventUuid,
-          adminUuid: admin.uuid,
-          permission,
-        })),
-      });
+      try {
+        await tx.eventPermission.createMany({
+          data: permissions.map((permission) => ({
+            eventUuid,
+            adminUuid: admin.uuid,
+            permission,
+          })),
+        });
+      } catch (error) {
+        if (
+          error instanceof Prisma.PrismaClientKnownRequestError &&
+          error.code === "P2002"
+        ) {
+          throw new BadRequestException(
+            "One or more permissions already exist for this organizer in this event",
+          );
+        }
+
+        throw error;
+      }
 
       return tx.admin.findUnique({
         where: { uuid: admin.uuid },


### PR DESCRIPTION
closes #49 

co do EventPermissions - dalej tworzymy osobny rekord dla kazdej permisji, bo mamy w schemie:
 permission     PermissionType 
zamiast:
 permission     PermissionType[], 
jak probowalem to zmienic to sie auth wysypywal wiec zostawilem jak jest, ale nie wiem czy chcemy to zmieniac xdd

do PermissionType dodalem tez MANAGE_SETTINGS, zeby bylo tak jak w v2

posprzatalem tez troche w serwisie i w testach, powinno to byc bardziej czytelne


