### PR TITLE
feat: email module

### DIFF
--- a/prisma/migrations/20260316201516_email_template_schema_update/migration.sql
+++ b/prisma/migrations/20260316201516_email_template_schema_update/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "EmailTemplates" ADD COLUMN     "order" INTEGER;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -179,6 +179,7 @@ model EmailTemplate {
   updatedAt     DateTime     @updatedAt
   triggerValue  String?
   triggerValue2 String?
+  order         Int?
   eventUuid     String?      @db.Uuid
   formUuid      String?      @db.Uuid
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -180,7 +180,7 @@ model EmailTemplate {
   triggerValue  String?
   triggerValue2 String?
   order         Int?
-  eventUuid     String?      @db.Uuid
+  eventUuid     String       @db.Uuid
   formUuid      String?      @db.Uuid
 
   event             Event?                   @relation(fields: [eventUuid], references: [uuid], onDelete: Cascade)

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -9,6 +9,7 @@ import { AppService } from "./app.service";
 import { AttributesModule } from "./attributes/attributes.module";
 import { AuthModule } from "./auth/auth.module";
 import { BlocksModule } from "./blocks/blocks.module";
+import { EmailsService } from "./emails/emails.service";
 import { EventsModule } from "./events/events.module";
 import { FormsModule } from "./forms/forms.module";
 import { OrganizersModule } from "./organizers/organizers.module";
@@ -35,6 +36,6 @@ import { PrismaModule } from "./prisma/prisma.module";
     ParticipantsModule,
   ],
   controllers: [AppController],
-  providers: [AppService],
+  providers: [AppService, EmailsService],
 })
 export class AppModule {}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -9,7 +9,7 @@ import { AppService } from "./app.service";
 import { AttributesModule } from "./attributes/attributes.module";
 import { AuthModule } from "./auth/auth.module";
 import { BlocksModule } from "./blocks/blocks.module";
-import { EmailsService } from "./emails/emails.service";
+import { EmailsModule } from "./emails/emails.module";
 import { EventsModule } from "./events/events.module";
 import { FormsModule } from "./forms/forms.module";
 import { OrganizersModule } from "./organizers/organizers.module";
@@ -34,8 +34,9 @@ import { PrismaModule } from "./prisma/prisma.module";
     BlocksModule,
     AdminsModule,
     ParticipantsModule,
+    EmailsModule,
   ],
   controllers: [AppController],
-  providers: [AppService, EmailsService],
+  providers: [AppService],
 })
 export class AppModule {}

--- a/src/emails/dto/create-email.dto.ts
+++ b/src/emails/dto/create-email.dto.ts
@@ -9,21 +9,28 @@ import {
 } from "class-validator";
 import { EmailTrigger } from "src/generated/prisma/enums";
 
+import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
+
 export class CreateEmailDto {
+  @ApiProperty({ example: "Email template name" })
   @IsString()
   @IsNotEmpty()
   name: string;
+  @ApiProperty({ example: "<p>Content</p>" })
   @IsString()
   @IsNotEmpty()
   content: string;
 
+  @ApiPropertyOptional()
   @IsNumber()
   @IsOptional()
   order?: number;
 
+  @ApiProperty({ enum: EmailTrigger, example: EmailTrigger.MANUAL })
   @IsEnum(EmailTrigger)
   trigger: EmailTrigger;
 
+  @ApiPropertyOptional()
   @ValidateIf(
     (o: CreateEmailDto) =>
       o.trigger === EmailTrigger.FORM_FILLED ||
@@ -34,6 +41,7 @@ export class CreateEmailDto {
   @IsString()
   triggerValue?: string;
 
+  @ApiPropertyOptional()
   @ValidateIf(
     (o: CreateEmailDto) =>
       o.trigger === EmailTrigger.FORM_FILLED ||
@@ -44,6 +52,7 @@ export class CreateEmailDto {
   @IsString()
   triggerValue2?: string;
 
+  @ApiPropertyOptional({ example: "test-form-uuid" })
   @IsUUID("4", { each: true })
   @IsOptional()
   formId?: string;

--- a/src/emails/dto/create-email.dto.ts
+++ b/src/emails/dto/create-email.dto.ts
@@ -1,0 +1,50 @@
+import {
+  IsEnum,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
+  IsUUID,
+  ValidateIf,
+} from "class-validator";
+import { EmailTrigger } from "src/generated/prisma/enums";
+
+export class CreateEmailDto {
+  @IsString()
+  @IsNotEmpty()
+  name: string;
+  @IsString()
+  @IsNotEmpty()
+  content: string;
+
+  @IsNumber()
+  @IsOptional()
+  order?: number;
+
+  @IsEnum(EmailTrigger)
+  trigger: EmailTrigger;
+
+  @ValidateIf(
+    (o: CreateEmailDto) =>
+      o.trigger === EmailTrigger.FORM_FILLED ||
+      o.trigger === EmailTrigger.ATTRIBUTE_CHANGED ||
+      o.triggerValue !== undefined,
+  )
+  @IsNotEmpty()
+  @IsString()
+  triggerValue?: string;
+
+  @ValidateIf(
+    (o: CreateEmailDto) =>
+      o.trigger === EmailTrigger.FORM_FILLED ||
+      o.trigger === EmailTrigger.ATTRIBUTE_CHANGED ||
+      o.triggerValue2 !== undefined,
+  )
+  @IsNotEmpty()
+  @IsString()
+  triggerValue2?: string;
+
+  @IsUUID("4", { each: true })
+  @IsOptional()
+  formId?: string;
+}

--- a/src/emails/dto/email-complete-element.dto.ts
+++ b/src/emails/dto/email-complete-element.dto.ts
@@ -1,0 +1,22 @@
+import type { EmailStatus } from "src/generated/prisma/enums";
+
+import { EmailElementDto } from "./email-element.dto";
+
+export class EmailCompleteElement extends EmailElementDto {
+  content: string;
+  formId: string | null;
+  order: number | null;
+  participants: EmailParticipant[];
+}
+
+class EmailParticipant {
+  id?: string;
+  email?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  meta: {
+    pivot_status: EmailStatus;
+    pivot_send_at: string;
+    pivot_send_by: string | null;
+  };
+}

--- a/src/emails/dto/email-complete-element.dto.ts
+++ b/src/emails/dto/email-complete-element.dto.ts
@@ -2,7 +2,7 @@ import type { EmailStatus } from "src/generated/prisma/enums";
 
 import { EmailElementDto } from "./email-element.dto";
 
-export class EmailCompleteElement extends EmailElementDto {
+export class EmailCompleteElementDto extends EmailElementDto {
   content: string;
   formId: string | null;
   order: number | null;

--- a/src/emails/dto/email-element.dto.ts
+++ b/src/emails/dto/email-element.dto.ts
@@ -1,0 +1,12 @@
+import type { EmailTrigger } from "src/generated/prisma/enums";
+
+export class EmailElementDto {
+  id: string;
+  eventId: string;
+  name: string;
+  trigger: EmailTrigger;
+  triggerValue: string;
+  triggerValue2: string;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/src/emails/dto/email-element.dto.ts
+++ b/src/emails/dto/email-element.dto.ts
@@ -5,8 +5,8 @@ export class EmailElementDto {
   eventId: string;
   name: string;
   trigger: EmailTrigger;
-  triggerValue: string;
-  triggerValue2: string;
+  triggerValue: string | null;
+  triggerValue2: string | null;
   createdAt: string;
   updatedAt: string;
 }

--- a/src/emails/dto/email-list-element.dto.ts
+++ b/src/emails/dto/email-list-element.dto.ts
@@ -1,0 +1,9 @@
+import { EmailElementDto } from "./email-element.dto";
+
+export class EmailListElementDto extends EmailElementDto {
+  meta: {
+    failedCount: number;
+    pendingCount: number;
+    sentCount: number;
+  };
+}

--- a/src/emails/dto/email-listing.dto.ts
+++ b/src/emails/dto/email-listing.dto.ts
@@ -1,0 +1,6 @@
+import { PageOptionsDto } from "src/common/dto/page-options.dto";
+import type { EmailTrigger } from "src/generated/prisma/enums";
+
+export class EmailListingDto extends PageOptionsDto {
+  trigger?: EmailTrigger;
+}

--- a/src/emails/dto/email-response.dto.ts
+++ b/src/emails/dto/email-response.dto.ts
@@ -1,0 +1,9 @@
+export class EmailResponseDto {
+  id: string;
+  name: string;
+  content: string;
+  trigger: string;
+  eventId: string;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/src/emails/dto/update-email.dto.ts
+++ b/src/emails/dto/update-email.dto.ts
@@ -1,0 +1,5 @@
+import { PartialType } from "@nestjs/swagger";
+
+import { CreateEmailDto } from "./create-email.dto";
+
+export class UpdateEmailDto extends PartialType(CreateEmailDto) {}

--- a/src/emails/emails.controller.ts
+++ b/src/emails/emails.controller.ts
@@ -1,0 +1,138 @@
+import { JwtAuthGuard } from "src/auth/jwt-auth.guard";
+import { RequirePermission } from "src/auth/permissions.decorator";
+import { PermissionsGuard } from "src/auth/permissions.guard";
+import { ApiPaginatedResponse } from "src/common/decorators/api-paginated-response.decorator";
+import { PermissionType } from "src/generated/prisma/enums";
+
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseUUIDPipe,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from "@nestjs/common";
+import {
+  ApiBadRequestResponse,
+  ApiBearerAuth,
+  ApiCreatedResponse,
+  ApiForbiddenResponse,
+  ApiNoContentResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiParam,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from "@nestjs/swagger";
+
+import { CreateEmailDto } from "./dto/create-email.dto";
+import { EmailCompleteElementDto } from "./dto/email-complete-element.dto";
+import { EmailListElementDto } from "./dto/email-list-element.dto";
+import { EmailListingDto } from "./dto/email-listing.dto";
+import { EmailResponseDto } from "./dto/email-response.dto";
+import { UpdateEmailDto } from "./dto/update-email.dto";
+import { EmailsService } from "./emails.service";
+
+@ApiTags("EmailTemplates")
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard, PermissionsGuard)
+@ApiUnauthorizedResponse({ description: "Unauthorized" })
+@ApiForbiddenResponse({ description: "Forbidden - insufficient permissions" })
+@Controller("events/:eventId/emails")
+export class EmailsController {
+  constructor(private readonly emailsService: EmailsService) {}
+
+  @Post()
+  @RequirePermission(PermissionType.MANAGE_EMAIL)
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: "Add an email template to event" })
+  @ApiParam({ name: "eventId", description: "UUID of the event" })
+  @ApiCreatedResponse({
+    description: "Email template added sucessfully",
+    type: EmailResponseDto,
+  })
+  @ApiBadRequestResponse({ description: "Event or Form not found." })
+  async create(
+    @Param("eventId", ParseUUIDPipe) eventId: string,
+    @Body() query: CreateEmailDto,
+  ) {
+    return this.emailsService.create(eventId, query);
+  }
+
+  @Get()
+  @RequirePermission(PermissionType.MANAGE_EMAIL)
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: "Get all email templates for an event" })
+  @ApiParam({ name: "eventId", description: "UUID of the event" })
+  @ApiPaginatedResponse(EmailListElementDto)
+  @ApiBadRequestResponse({ description: "Event with this UUID not found" })
+  async findAll(
+    @Param("eventId", ParseUUIDPipe) eventId: string,
+    @Query() query: EmailListingDto,
+  ) {
+    return this.emailsService.findAll(eventId, query);
+  }
+
+  @Get(":emailId")
+  @RequirePermission(PermissionType.MANAGE_EMAIL)
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: "Get an email template by event id and email id" })
+  @ApiParam({ name: "eventId", description: "UUID of the event" })
+  @ApiParam({ name: "emailId", description: "UUID of the email" })
+  @ApiOkResponse({
+    description: "Email template retrieved successfully",
+    type: EmailCompleteElementDto,
+  })
+  @ApiNotFoundResponse({ description: "Event or email does not exist" })
+  async findOne(
+    @Param("eventId", ParseUUIDPipe) eventId: string,
+    @Param("emailId", ParseUUIDPipe) emailId: string,
+  ) {
+    return this.emailsService.findOne(eventId, emailId);
+  }
+
+  @Patch(":emailId")
+  @RequirePermission(PermissionType.MANAGE_EMAIL)
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: "Update email template" })
+  @ApiParam({ name: "eventId", description: "UUID of the event" })
+  @ApiParam({ name: "emailId", description: "UUID of the email" })
+  @ApiOkResponse({
+    description: "Email template updated successfully",
+    type: EmailResponseDto,
+  })
+  @ApiNotFoundResponse({
+    description: "Email template or event does not exist",
+  })
+  async update(
+    @Param("eventId", ParseUUIDPipe) eventId: string,
+    @Param("emailId", ParseUUIDPipe) emailId: string,
+    @Body() query: UpdateEmailDto,
+  ) {
+    return this.emailsService.update(eventId, emailId, query);
+  }
+
+  @Delete(":emailId")
+  @RequirePermission(PermissionType.MANAGE_EMAIL)
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: "Delete email template" })
+  @ApiParam({ name: "eventId", description: "UUID of the event" })
+  @ApiParam({ name: "emailId", description: "UUID of the email" })
+  @ApiNoContentResponse({ description: "Email template deleted successfully" })
+  @ApiNotFoundResponse({
+    description: "Email template or event does not exist",
+  })
+  async remove(
+    @Param("eventId", ParseUUIDPipe) eventId: string,
+    @Param("emailId", ParseUUIDPipe) emailId: string,
+  ) {
+    return this.emailsService.remove(eventId, emailId);
+  }
+}

--- a/src/emails/emails.int.spec.ts
+++ b/src/emails/emails.int.spec.ts
@@ -1,0 +1,314 @@
+import { EmailStatus, EmailTrigger } from "src/generated/prisma/enums";
+import { PrismaService } from "src/prisma/prisma.service";
+
+import { BadRequestException, NotFoundException } from "@nestjs/common";
+import type { TestingModule } from "@nestjs/testing";
+import { Test } from "@nestjs/testing";
+
+import type { CreateEmailDto } from "./dto/create-email.dto";
+import { EmailListingDto } from "./dto/email-listing.dto";
+import type { UpdateEmailDto } from "./dto/update-email.dto";
+import { EmailsController } from "./emails.controller";
+import { EmailsService } from "./emails.service";
+
+describe("EmailsController", () => {
+  let controller: EmailsController;
+  const mockEventId = "event-uuid-123";
+  const mockEmailId = "email-uuid-123";
+
+  const mockPrismaService = {
+    event: {
+      findUnique: jest.fn(),
+    },
+    form: {
+      findUnique: jest.fn(),
+    },
+    emailTemplate: {
+      findMany: jest.fn(),
+      findFirst: jest.fn(),
+      findUnique: jest.fn(),
+      findUniqueOrThrow: jest.fn(),
+      update: jest.fn(),
+      create: jest.fn(),
+      delete: jest.fn(),
+      count: jest.fn(),
+    },
+    $transaction: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [EmailsService, PrismaService],
+      controllers: [EmailsController],
+    })
+      .overrideProvider(PrismaService)
+      .useValue(mockPrismaService)
+      .compile();
+
+    controller = module.get<EmailsController>(EmailsController);
+
+    mockPrismaService.$transaction.mockImplementation(async (argument) => {
+      if (Array.isArray(argument)) {
+        return Promise.all(argument);
+      }
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call
+      return argument(mockPrismaService);
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.resetAllMocks();
+  });
+
+  it("should be defined", () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe("find all emails by event", () => {
+    it("should return a paginated list of email templates", async () => {
+      const query: EmailListingDto = {
+        skip: 0,
+        take: 10,
+        sort: "createdAt:desc",
+      };
+      const mockDate = new Date();
+
+      const mockPrismaOutput = [
+        {
+          uuid: mockEmailId,
+          eventUuid: mockEventId,
+          name: "<p>test</p>",
+          trigger: EmailTrigger.MANUAL,
+          triggerValue: null,
+          triggerValue2: null,
+          createdAt: mockDate,
+          updatedAt: mockDate,
+          participantEmails: [
+            { status: EmailStatus.sent },
+            { status: EmailStatus.sent },
+            { status: EmailStatus.failed },
+          ],
+        },
+      ];
+
+      mockPrismaService.event.findUnique.mockResolvedValue({
+        uuid: mockEventId,
+      });
+      mockPrismaService.emailTemplate.count.mockResolvedValue(
+        mockPrismaOutput.length,
+      );
+      mockPrismaService.emailTemplate.findMany.mockResolvedValue(
+        mockPrismaOutput,
+      );
+
+      const result = await controller.findAll(mockEventId, query);
+
+      expect(result.meta.itemCount).toEqual(1);
+      expect(result.data).toHaveLength(1);
+
+      expect(result.data[0]).toEqual(
+        expect.objectContaining({
+          id: mockEmailId,
+          name: "<p>test</p>",
+          meta: {
+            sentCount: 2,
+            failedCount: 1,
+            pendingCount: 0,
+          },
+        }),
+      );
+
+      expect(mockPrismaService.emailTemplate.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          where: expect.objectContaining({
+            eventUuid: mockEventId,
+          }),
+          take: 10,
+          skip: 0,
+          orderBy: [{ createdAt: "desc" }],
+        }),
+      );
+    });
+
+    it("should throw BadRequestException if the event does not exist", async () => {
+      const query = new EmailListingDto();
+      mockPrismaService.event.findUnique.mockResolvedValue(null);
+
+      await expect(controller.findAll(mockEventId, query)).rejects.toThrow(
+        BadRequestException,
+      );
+
+      expect(mockPrismaService.emailTemplate.count).not.toHaveBeenCalled();
+      expect(mockPrismaService.emailTemplate.findMany).not.toHaveBeenCalled();
+      expect(mockPrismaService.$transaction).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("create an email template", () => {
+    it("should successfully create and return the email template", async () => {
+      const dto: CreateEmailDto = {
+        name: "test",
+        content: "<p>Hello</p>",
+        trigger: EmailTrigger.MANUAL,
+      };
+
+      const mockPrismaOutput = {
+        uuid: mockEmailId,
+        eventUuid: mockEventId,
+        name: dto.name,
+        content: dto.content,
+        trigger: dto.trigger,
+        triggerValue: null,
+        triggerValue2: null,
+        formUuid: null,
+        order: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      mockPrismaService.event.findUnique.mockResolvedValue({
+        uuid: mockEventId,
+      });
+      mockPrismaService.emailTemplate.create.mockResolvedValue(
+        mockPrismaOutput,
+      );
+
+      const result = await controller.create(mockEventId, dto);
+
+      expect(result.id).toEqual(mockEmailId);
+      expect(result.name).toEqual("test");
+      expect(mockPrismaService.emailTemplate.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          data: expect.objectContaining({
+            name: "test",
+            content: "<p>Hello</p>",
+          }),
+        }),
+      );
+    });
+
+    it("should throw BadRequestException when the event doesn't exist", async () => {
+      const dto: CreateEmailDto = {
+        name: "test",
+        content: "<p>test</p>",
+        trigger: EmailTrigger.MANUAL,
+      };
+      mockPrismaService.event.findUnique.mockResolvedValue(null);
+
+      await expect(controller.create(mockEventId, dto)).rejects.toThrow(
+        BadRequestException,
+      );
+      expect(mockPrismaService.emailTemplate.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("find one email by event", () => {
+    it("should return a complete email template with participants", async () => {
+      const mockPrismaOutput = {
+        uuid: mockEmailId,
+        eventUuid: mockEventId,
+        name: "Single Email",
+        content: "<p>Content</p>",
+        trigger: EmailTrigger.MANUAL,
+        triggerValue: null,
+        triggerValue2: null,
+        formUuid: null,
+        order: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        participantEmails: [],
+      };
+
+      mockPrismaService.emailTemplate.findFirst.mockResolvedValue(
+        mockPrismaOutput,
+      );
+
+      const result = await controller.findOne(mockEventId, mockEmailId);
+
+      expect(result.id).toEqual(mockEmailId);
+      expect(result.name).toEqual("Single Email");
+      expect(result.participants).toEqual([]);
+    });
+
+    it("should throw NotFoundException when the email does not exist", async () => {
+      mockPrismaService.emailTemplate.findFirst.mockResolvedValue(null);
+
+      await expect(
+        controller.findOne(mockEventId, mockEmailId),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe("update an email template", () => {
+    it("should update and return the email template", async () => {
+      const dto: UpdateEmailDto = { name: "test2" };
+
+      mockPrismaService.emailTemplate.findFirst.mockResolvedValue({
+        uuid: mockEmailId,
+      });
+
+      const mockUpdatedOutput = {
+        uuid: mockEmailId,
+        eventUuid: mockEventId,
+        name: "test2",
+        content: "<p>test</p>",
+        trigger: EmailTrigger.MANUAL,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      mockPrismaService.emailTemplate.update.mockResolvedValue(
+        mockUpdatedOutput,
+      );
+
+      const result = await controller.update(mockEventId, mockEmailId, dto);
+
+      expect(result.name).toEqual("test2");
+      expect(mockPrismaService.emailTemplate.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { uuid: mockEmailId },
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          data: expect.objectContaining({ name: "test2" }),
+        }),
+      );
+    });
+    it("should throw NotFoundException when event or email does not exist", async () => {
+      const dto: UpdateEmailDto = { name: "test" };
+      mockPrismaService.emailTemplate.findFirst.mockResolvedValue(null);
+      await expect(
+        controller.update(mockEventId, mockEmailId, dto),
+      ).rejects.toThrow(NotFoundException);
+      expect(mockPrismaService.emailTemplate.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("delete an email template", () => {
+    it("should delete the email and return void", async () => {
+      mockPrismaService.emailTemplate.findFirst.mockResolvedValue({
+        uuid: mockEmailId,
+      });
+      mockPrismaService.emailTemplate.delete.mockResolvedValue({
+        uuid: mockEmailId,
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
+      const result = await controller.remove(mockEventId, mockEmailId);
+
+      expect(result).toBeUndefined();
+      expect(mockPrismaService.emailTemplate.delete).toHaveBeenCalledWith({
+        where: { uuid: mockEmailId },
+      });
+    });
+    it("should throw NotFoundException and prevent database deletion", async () => {
+      mockPrismaService.emailTemplate.findFirst.mockResolvedValue(null);
+
+      await expect(controller.remove(mockEventId, mockEmailId)).rejects.toThrow(
+        NotFoundException,
+      );
+      expect(mockPrismaService.emailTemplate.delete).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/emails/emails.module.ts
+++ b/src/emails/emails.module.ts
@@ -1,0 +1,10 @@
+import { Module } from "@nestjs/common";
+
+import { EmailsController } from "./emails.controller";
+import { EmailsService } from "./emails.service";
+
+@Module({
+  controllers: [EmailsController],
+  providers: [EmailsService],
+})
+export class EmailsModule {}

--- a/src/emails/emails.service.spec.ts
+++ b/src/emails/emails.service.spec.ts
@@ -476,7 +476,7 @@ describe("EmailsService", () => {
 
       // Check whether delete() returns undefined.
       // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
-      const result = await service.delete(mockEventId, mockEmailId);
+      const result = await service.remove(mockEventId, mockEmailId);
 
       expect(mockPrismaService.emailTemplate.findFirst).toHaveBeenCalledWith({
         where: {
@@ -497,7 +497,7 @@ describe("EmailsService", () => {
       mockTransaction(mockPrismaService);
       mockPrismaService.emailTemplate.findFirst.mockResolvedValue(null);
 
-      await expect(service.delete(mockEventId, mockEmailId)).rejects.toThrow(
+      await expect(service.remove(mockEventId, mockEmailId)).rejects.toThrow(
         NotFoundException,
       );
       expect(mockPrismaService.emailTemplate.delete).not.toHaveBeenCalled();

--- a/src/emails/emails.service.spec.ts
+++ b/src/emails/emails.service.spec.ts
@@ -1,0 +1,110 @@
+import { EmailTrigger } from "src/generated/prisma/enums";
+import { PrismaService } from "src/prisma/prisma.service";
+
+import { BadRequestException } from "@nestjs/common";
+import type { TestingModule } from "@nestjs/testing";
+import { Test } from "@nestjs/testing";
+
+import type { CreateEmailDto } from "./dto/create-email.dto";
+import { EmailsService } from "./emails.service";
+
+describe("EmailsService", () => {
+  let service: EmailsService;
+  const mockEventId = "event-uuid-123";
+  const mockEmailId = "email-uuid-123";
+
+  const mockPrismaService = {
+    event: {
+      findUnique: jest.fn(),
+    },
+    form: {
+      findUnique: jest.fn(),
+    },
+    emailTemplate: {
+      findMany: jest.fn(),
+      findFirst: jest.fn(),
+      findUnique: jest.fn(),
+      findUniqueOrThrow: jest.fn(),
+      update: jest.fn(),
+      create: jest.fn(),
+      delete: jest.fn(),
+    },
+    $transaction: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [EmailsService, PrismaService],
+    })
+      .overrideProvider(PrismaService)
+      .useValue(mockPrismaService)
+      .compile();
+
+    service = module.get<EmailsService>(EmailsService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.resetAllMocks();
+  });
+
+  it("should be defined", () => {
+    expect(service).toBeDefined();
+  });
+
+  describe("create", () => {
+    it("should create a new email template", async () => {
+      const dto = {
+        name: "Name",
+        content: "Content",
+        trigger: EmailTrigger.MANUAL,
+      };
+
+      mockTransaction(mockPrismaService);
+
+      mockPrismaService.event.findUnique.mockResolvedValue({
+        uuid: mockEventId,
+      });
+
+      mockPrismaService.emailTemplate.create.mockResolvedValue({
+        uuid: mockEmailId,
+        name: dto.name,
+        content: dto.content,
+        trigger: dto.trigger,
+      });
+
+      const result = await service.create(mockEventId, dto as CreateEmailDto);
+
+      expect(mockPrismaService.emailTemplate.create).toHaveBeenCalledWith({
+        data: {
+          name: dto.name,
+          content: dto.content,
+          trigger: dto.trigger,
+          eventUuid: mockEventId,
+        },
+      });
+
+      expect(result.id).toEqual(mockEmailId);
+    });
+    it("should throw BadRequestException when provided eventId does not exist", async () => {
+      const dto = {
+        name: "Name",
+        content: "Content",
+        trigger: EmailTrigger.MANUAL,
+      };
+      mockPrismaService.event.findUnique.mockResolvedValue(null);
+      mockTransaction(mockPrismaService);
+      await expect(
+        service.create(mockEventId, dto as CreateEmailDto),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+});
+
+function mockTransaction(mockPrismaService: { $transaction: jest.Mock }) {
+  mockPrismaService.$transaction.mockImplementation(
+    async (callback: (tx: typeof mockPrismaService) => Promise<unknown>) => {
+      return await callback(mockPrismaService);
+    },
+  );
+}

--- a/src/emails/emails.service.spec.ts
+++ b/src/emails/emails.service.spec.ts
@@ -1,7 +1,7 @@
 import { EmailStatus, EmailTrigger } from "src/generated/prisma/enums";
 import { PrismaService } from "src/prisma/prisma.service";
 
-import { BadRequestException } from "@nestjs/common";
+import { BadRequestException, NotFoundException } from "@nestjs/common";
 import type { TestingModule } from "@nestjs/testing";
 import { Test } from "@nestjs/testing";
 
@@ -174,7 +174,7 @@ describe("EmailsService", () => {
         },
       ];
 
-      mockPrismaService.event.findUnique.mockReturnValue(mockEventId);
+      mockPrismaService.event.findUnique.mockResolvedValue(mockEventId);
       mockPrismaService.$transaction.mockResolvedValue([
         mockPrismaOutput.length,
         mockPrismaOutput,
@@ -248,7 +248,7 @@ describe("EmailsService", () => {
         },
       ];
 
-      mockPrismaService.event.findUnique.mockReturnValue(mockEventId);
+      mockPrismaService.event.findUnique.mockResolvedValue(mockEventId);
       mockPrismaService.$transaction.mockResolvedValue([
         mockPrismaOutput.length,
         mockPrismaOutput,
@@ -284,11 +284,109 @@ describe("EmailsService", () => {
         page: 1,
         take: 10,
         skip: 0,
-      } as unknown as EmailListingDto;
+      } as EmailListingDto;
 
-      mockPrismaService.event.findUnique.mockReturnValue(null);
+      mockPrismaService.event.findUnique.mockResolvedValue(null);
       await expect(service.findAll(mockEventId, query)).rejects.toThrow(
         BadRequestException,
+      );
+    });
+  });
+
+  describe("findOne", () => {
+    it("should return an email template for provided emailId and eventId", async () => {
+      const mockPrismaOutput = {
+        uuid: mockEmailId,
+        eventUuid: mockEventId,
+        name: "test",
+        content: "<p>test</p>",
+        trigger: EmailTrigger.MANUAL,
+        triggerValue: "",
+        triggerValue2: "",
+        formUuid: null,
+        order: 0,
+        createdAt: new Date("2025-02-22T19:13:10.471Z"),
+        updatedAt: new Date("2025-02-22T19:13:10.471Z"),
+        participantEmails: [
+          {
+            uuid: "pivot-uuid-123",
+            status: EmailStatus.sent,
+            sendAt: new Date("2025-02-22T19:13:10.471Z"),
+            createdAt: new Date("2025-02-22T19:13:10.471Z"),
+            updatedAt: new Date("2025-02-22T19:13:10.471Z"),
+            sendBy: "Jan Kowalski",
+            participantUuid: "participant-uuid-123",
+            emailUuid: "email-uuid-123",
+            participant: {
+              uuid: "participant-uuid-123",
+              email: "example@example.com",
+              eventUuid: "event-uuid-123",
+              createdAt: new Date("2025-02-22T19:13:10.471Z"),
+              updatedAt: new Date("2025-02-22T19:13:10.471Z"),
+            },
+          },
+        ],
+      };
+      const expectedOutput = {
+        id: mockEmailId,
+        eventId: mockEventId,
+        name: "test",
+        content: "<p>test</p>",
+        trigger: EmailTrigger.MANUAL,
+        triggerValue: "",
+        triggerValue2: "",
+        formId: null,
+        order: 0,
+        createdAt: "2025-02-22T19:13:10.471Z",
+        updatedAt: "2025-02-22T19:13:10.471Z",
+        participants: [
+          {
+            id: "participant-uuid-123",
+            email: "example@example.com",
+            createdAt: "2025-02-22T19:13:10.471Z",
+            updatedAt: "2025-02-22T19:13:10.471Z",
+            meta: {
+              pivot_status: EmailStatus.sent,
+              pivot_send_at: "2025-02-22T19:13:10.471Z",
+              pivot_send_by: "Jan Kowalski",
+            },
+          },
+        ],
+      };
+
+      mockPrismaService.emailTemplate.findFirst.mockResolvedValue(
+        mockPrismaOutput,
+      );
+
+      const result = await service.findOne(mockEventId, mockEmailId);
+
+      expect(mockPrismaService.emailTemplate.findFirst).toHaveBeenCalledWith({
+        where: {
+          uuid: mockEmailId,
+          eventUuid: mockEventId,
+        },
+        include: {
+          participantEmails: {
+            include: {
+              participant: true,
+            },
+          },
+        },
+      });
+      expect(result).toEqual(expectedOutput);
+    });
+
+    it("should throw NotFoundException when event with provided eventId does not exist.", async () => {
+      mockPrismaService.emailTemplate.findFirst.mockResolvedValue(null);
+      await expect(service.findOne(mockEventId, mockEmailId)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it("should throw NotFoundException when email with provided emailId does not exist.", async () => {
+      mockPrismaService.emailTemplate.findFirst.mockResolvedValue(null);
+      await expect(service.findOne(mockEventId, mockEmailId)).rejects.toThrow(
+        NotFoundException,
       );
     });
   });

--- a/src/emails/emails.service.spec.ts
+++ b/src/emails/emails.service.spec.ts
@@ -1,4 +1,4 @@
-import { EmailTrigger } from "src/generated/prisma/enums";
+import { EmailStatus, EmailTrigger } from "src/generated/prisma/enums";
 import { PrismaService } from "src/prisma/prisma.service";
 
 import { BadRequestException } from "@nestjs/common";
@@ -6,6 +6,7 @@ import type { TestingModule } from "@nestjs/testing";
 import { Test } from "@nestjs/testing";
 
 import type { CreateEmailDto } from "./dto/create-email.dto";
+import type { EmailListingDto } from "./dto/email-listing.dto";
 import { EmailsService } from "./emails.service";
 
 describe("EmailsService", () => {
@@ -28,6 +29,7 @@ describe("EmailsService", () => {
       update: jest.fn(),
       create: jest.fn(),
       delete: jest.fn(),
+      count: jest.fn(),
     },
     $transaction: jest.fn(),
   };
@@ -86,7 +88,7 @@ describe("EmailsService", () => {
 
       expect(result.id).toEqual(mockEmailId);
     });
-    it("should throw BadRequestException when provided eventId does not exist", async () => {
+    it("should throw BadRequestException when an event with provided eventId does not exist", async () => {
       const dto = {
         name: "Name",
         content: "Content",
@@ -97,6 +99,197 @@ describe("EmailsService", () => {
       await expect(
         service.create(mockEventId, dto as CreateEmailDto),
       ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe("findAll", () => {
+    it("should return paginated email templates with a default sort", async () => {
+      const query = {
+        page: 1,
+        take: 10,
+        skip: 0,
+      } as EmailListingDto;
+
+      const mockPrismaOutput = [
+        {
+          uuid: "email-uuid-123",
+          eventUuid: "event-uuid-123",
+          name: "test124",
+          trigger: EmailTrigger.PARTICIPANT_REGISTERED,
+          triggerValue: "",
+          triggerValue2: "",
+          createdAt: new Date("2025-02-22T19:13:10.471Z"),
+          updatedAt: new Date("2025-02-22T19:13:10.471Z"),
+          participantEmails: [
+            { status: EmailStatus.sent },
+            { status: EmailStatus.failed },
+          ],
+        },
+        {
+          uuid: "email-uuid-234",
+          eventUuid: "event-uuid-123",
+          name: "test245",
+          trigger: EmailTrigger.MANUAL,
+          triggerValue: "",
+          triggerValue2: "",
+          createdAt: new Date("2025-02-22T19:13:10.471Z"),
+          updatedAt: new Date("2025-02-22T19:13:10.471Z"),
+          participantEmails: [
+            { status: EmailStatus.sent },
+            { status: EmailStatus.failed },
+          ],
+        },
+      ];
+
+      const expectedOutput = [
+        {
+          id: "email-uuid-123",
+          eventId: mockEventId,
+          name: "test124",
+          trigger: EmailTrigger.PARTICIPANT_REGISTERED,
+          triggerValue: "",
+          triggerValue2: "",
+          createdAt: "2025-02-22T19:13:10.471Z",
+          updatedAt: "2025-02-22T19:13:10.471Z",
+          meta: {
+            failedCount: 1,
+            pendingCount: 0,
+            sentCount: 1,
+          },
+        },
+        {
+          id: "email-uuid-234",
+          eventId: mockEventId,
+          name: "test245",
+          trigger: EmailTrigger.MANUAL,
+          triggerValue: "",
+          triggerValue2: "",
+          createdAt: "2025-02-22T19:13:10.471Z",
+          updatedAt: "2025-02-22T19:13:10.471Z",
+          meta: {
+            failedCount: 1,
+            pendingCount: 0,
+            sentCount: 1,
+          },
+        },
+      ];
+
+      mockPrismaService.event.findUnique.mockReturnValue(mockEventId);
+      mockPrismaService.$transaction.mockResolvedValue([
+        mockPrismaOutput.length,
+        mockPrismaOutput,
+      ]);
+
+      const result = await service.findAll(mockEventId, query);
+
+      expect(mockPrismaService.emailTemplate.findMany).toHaveBeenCalledWith({
+        where: { eventUuid: mockEventId },
+        skip: query.skip,
+        take: query.take,
+        orderBy: [{ createdAt: "desc" }],
+        select: {
+          uuid: true,
+          eventUuid: true,
+          name: true,
+          trigger: true,
+          triggerValue: true,
+          triggerValue2: true,
+          createdAt: true,
+          updatedAt: true,
+          participantEmails: {
+            select: { status: true },
+          },
+        },
+      });
+      expect(result.data).toEqual(expectedOutput);
+      expect(result.meta.itemCount).toBe(expectedOutput.length);
+    });
+
+    it("should return filtered and paginated email templates", async () => {
+      const query = {
+        page: 1,
+        take: 10,
+        skip: 0,
+        trigger: EmailTrigger.MANUAL,
+      } as EmailListingDto;
+
+      const mockPrismaOutput = [
+        {
+          uuid: "email-uuid-234",
+          eventUuid: "event-uuid-123",
+          name: "test245",
+          trigger: EmailTrigger.MANUAL,
+          triggerValue: "",
+          triggerValue2: "",
+          createdAt: new Date("2025-02-22T19:13:10.471Z"),
+          updatedAt: new Date("2025-02-22T19:13:10.471Z"),
+          participantEmails: [
+            { status: EmailStatus.sent },
+            { status: EmailStatus.failed },
+          ],
+        },
+      ];
+
+      const expectedOutput = [
+        {
+          id: "email-uuid-234",
+          eventId: mockEventId,
+          name: "test245",
+          trigger: EmailTrigger.MANUAL,
+          triggerValue: "",
+          triggerValue2: "",
+          createdAt: "2025-02-22T19:13:10.471Z",
+          updatedAt: "2025-02-22T19:13:10.471Z",
+          meta: {
+            failedCount: 1,
+            pendingCount: 0,
+            sentCount: 1,
+          },
+        },
+      ];
+
+      mockPrismaService.event.findUnique.mockReturnValue(mockEventId);
+      mockPrismaService.$transaction.mockResolvedValue([
+        mockPrismaOutput.length,
+        mockPrismaOutput,
+      ]);
+
+      const result = await service.findAll(mockEventId, query);
+
+      expect(mockPrismaService.emailTemplate.findMany).toHaveBeenCalledWith({
+        where: { eventUuid: mockEventId, trigger: query.trigger },
+        skip: query.skip,
+        take: query.take,
+        orderBy: [{ createdAt: "desc" }],
+        select: {
+          uuid: true,
+          eventUuid: true,
+          name: true,
+          trigger: true,
+          triggerValue: true,
+          triggerValue2: true,
+          createdAt: true,
+          updatedAt: true,
+          participantEmails: {
+            select: { status: true },
+          },
+        },
+      });
+      expect(result.data).toEqual(expectedOutput);
+      expect(result.meta.itemCount).toBe(expectedOutput.length);
+    });
+
+    it("should throw BadRequestException when an event with provided eventId does not exist", async () => {
+      const query = {
+        page: 1,
+        take: 10,
+        skip: 0,
+      } as unknown as EmailListingDto;
+
+      mockPrismaService.event.findUnique.mockReturnValue(null);
+      await expect(service.findAll(mockEventId, query)).rejects.toThrow(
+        BadRequestException,
+      );
     });
   });
 });

--- a/src/emails/emails.service.spec.ts
+++ b/src/emails/emails.service.spec.ts
@@ -7,6 +7,7 @@ import { Test } from "@nestjs/testing";
 
 import type { CreateEmailDto } from "./dto/create-email.dto";
 import type { EmailListingDto } from "./dto/email-listing.dto";
+import type { UpdateEmailDto } from "./dto/update-email.dto";
 import { EmailsService } from "./emails.service";
 
 describe("EmailsService", () => {
@@ -56,7 +57,7 @@ describe("EmailsService", () => {
 
   describe("create", () => {
     it("should create a new email template", async () => {
-      const dto = {
+      const dto: CreateEmailDto = {
         name: "Name",
         content: "Content",
         trigger: EmailTrigger.MANUAL,
@@ -73,9 +74,12 @@ describe("EmailsService", () => {
         name: dto.name,
         content: dto.content,
         trigger: dto.trigger,
+        eventId: mockEventId,
+        createdAt: new Date("2025-02-22T19:13:10.471Z"),
+        updatedAt: new Date("2025-02-22T19:13:10.471Z"),
       });
 
-      const result = await service.create(mockEventId, dto as CreateEmailDto);
+      const result = await service.create(mockEventId, dto);
 
       expect(mockPrismaService.emailTemplate.create).toHaveBeenCalledWith({
         data: {
@@ -388,6 +392,115 @@ describe("EmailsService", () => {
       await expect(service.findOne(mockEventId, mockEmailId)).rejects.toThrow(
         NotFoundException,
       );
+    });
+  });
+
+  describe("update", () => {
+    it("should update email template and return it", async () => {
+      const updateEmailDto: UpdateEmailDto = {
+        name: "test2",
+        content: "<p>test2</p>",
+      };
+
+      const mockPrismaOutput = {
+        uuid: mockEmailId,
+        eventUuid: mockEventId,
+        name: "test",
+        content: "<p>test2</p>",
+        trigger: EmailTrigger.MANUAL,
+        triggerValue: "",
+        triggerValue2: "",
+        formUuid: null,
+        order: 0,
+        createdAt: new Date("2025-02-22T19:13:10.471Z"),
+        updatedAt: new Date("2025-02-22T19:13:10.471Z"),
+      };
+      mockTransaction(mockPrismaService);
+      mockPrismaService.emailTemplate.findFirst.mockResolvedValue({
+        uuid: mockEmailId,
+      });
+      mockPrismaService.emailTemplate.update.mockResolvedValue(
+        mockPrismaOutput,
+      );
+      const result = await service.update(
+        mockEventId,
+        mockEmailId,
+        updateEmailDto,
+      );
+
+      expect(mockPrismaService.emailTemplate.update).toHaveBeenCalledWith({
+        where: {
+          uuid: mockEmailId,
+        },
+        data: {
+          name: "test2",
+          content: "<p>test2</p>",
+        },
+      });
+      expect(result).toEqual({
+        id: mockEmailId,
+        name: "test",
+        content: "<p>test2</p>",
+        trigger: EmailTrigger.MANUAL,
+        eventId: mockEventId,
+        createdAt: "2025-02-22T19:13:10.471Z",
+        updatedAt: "2025-02-22T19:13:10.471Z",
+      });
+    });
+    it("should throw NotFoundException when event with provided eventId does not exist.", async () => {
+      mockTransaction(mockPrismaService);
+      mockPrismaService.emailTemplate.findFirst.mockResolvedValue(null);
+      await expect(
+        service.update(mockEventId, mockEmailId, {} as UpdateEmailDto),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it("should throw NotFoundException when email with provided emailId does not exist.", async () => {
+      mockTransaction(mockPrismaService);
+      mockPrismaService.emailTemplate.findFirst.mockResolvedValue(null);
+      await expect(
+        service.update(mockEventId, mockEmailId, {} as UpdateEmailDto),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe("delete", () => {
+    it("should delete the email template and return nothing.", async () => {
+      mockTransaction(mockPrismaService);
+      mockPrismaService.emailTemplate.findFirst.mockResolvedValue({
+        uuid: mockEmailId,
+      });
+      mockPrismaService.emailTemplate.delete.mockResolvedValue({
+        uuid: mockEmailId,
+      });
+
+      // Check whether delete() returns undefined.
+      // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
+      const result = await service.delete(mockEventId, mockEmailId);
+
+      expect(mockPrismaService.emailTemplate.findFirst).toHaveBeenCalledWith({
+        where: {
+          uuid: mockEmailId,
+          eventUuid: mockEventId,
+        },
+        select: { uuid: true },
+      });
+
+      expect(mockPrismaService.emailTemplate.delete).toHaveBeenCalledWith({
+        where: { uuid: mockEmailId },
+      });
+
+      expect(result).toBeUndefined();
+    });
+
+    it("should throw NotFoundException when email or/and event does not exist.", async () => {
+      mockTransaction(mockPrismaService);
+      mockPrismaService.emailTemplate.findFirst.mockResolvedValue(null);
+
+      await expect(service.delete(mockEventId, mockEmailId)).rejects.toThrow(
+        NotFoundException,
+      );
+      expect(mockPrismaService.emailTemplate.delete).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/emails/emails.service.ts
+++ b/src/emails/emails.service.ts
@@ -1,0 +1,52 @@
+import { PrismaService } from "src/prisma/prisma.service";
+
+import { BadRequestException, Injectable } from "@nestjs/common";
+
+import { CreateEmailDto } from "./dto/create-email.dto";
+
+@Injectable()
+export class EmailsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async create(eventUuid: string, query: CreateEmailDto) {
+    return await this.prisma.$transaction(async (tx) => {
+      const event = await tx.event.findUnique({
+        where: { uuid: eventUuid },
+      });
+      if (event == null) {
+        throw new BadRequestException(`Event with id: ${eventUuid} not found`);
+      }
+
+      if (query.formId !== undefined) {
+        const form = await tx.form.findUnique({
+          where: { uuid: query.formId },
+        });
+        if (form == null) {
+          throw new BadRequestException(
+            `Form with id: ${query.formId} not found`,
+          );
+        }
+      }
+
+      const emailTemplate = await tx.emailTemplate.create({
+        data: {
+          name: query.name,
+          content: query.content,
+          trigger: query.trigger,
+          triggerValue: query.triggerValue,
+          triggerValue2: query.triggerValue2,
+          order: query.order,
+          eventUuid,
+          formUuid: query.formId,
+        },
+      });
+
+      return {
+        id: emailTemplate.uuid,
+        name: emailTemplate.name,
+        content: emailTemplate.content,
+        trigger: emailTemplate.trigger,
+      };
+    });
+  }
+}

--- a/src/emails/emails.service.ts
+++ b/src/emails/emails.service.ts
@@ -11,7 +11,7 @@ import {
 } from "@nestjs/common";
 
 import { CreateEmailDto } from "./dto/create-email.dto";
-import { EmailCompleteElement } from "./dto/email-complete-element.dto";
+import { EmailCompleteElementDto } from "./dto/email-complete-element.dto";
 import { EmailListElementDto } from "./dto/email-list-element.dto";
 import { EmailListingDto } from "./dto/email-listing.dto";
 import { EmailResponseDto } from "./dto/email-response.dto";
@@ -157,7 +157,7 @@ export class EmailsService {
   async findOne(
     eventUuid: string,
     emailUuid: string,
-  ): Promise<EmailCompleteElement> {
+  ): Promise<EmailCompleteElementDto> {
     const emailTemplate = await this.prisma.emailTemplate.findFirst({
       where: {
         uuid: emailUuid,
@@ -176,7 +176,7 @@ export class EmailsService {
       throw new NotFoundException("Email not found");
     }
 
-    const formattedResponse: EmailCompleteElement = {
+    const formattedResponse: EmailCompleteElementDto = {
       id: emailTemplate.uuid,
       eventId: emailTemplate.eventUuid,
       name: emailTemplate.name,
@@ -250,7 +250,7 @@ export class EmailsService {
     });
   }
 
-  async delete(eventUuid: string, emailUuid: string): Promise<void> {
+  async remove(eventUuid: string, emailUuid: string): Promise<void> {
     await this.prisma.$transaction(async (tx) => {
       const existingEmail = await tx.emailTemplate.findFirst({
         where: {

--- a/src/emails/emails.service.ts
+++ b/src/emails/emails.service.ts
@@ -14,13 +14,18 @@ import { CreateEmailDto } from "./dto/create-email.dto";
 import { EmailCompleteElement } from "./dto/email-complete-element.dto";
 import { EmailListElementDto } from "./dto/email-list-element.dto";
 import { EmailListingDto } from "./dto/email-listing.dto";
+import { EmailResponseDto } from "./dto/email-response.dto";
+import { UpdateEmailDto } from "./dto/update-email.dto";
 
 @Injectable()
 export class EmailsService {
   constructor(private readonly prisma: PrismaService) {}
 
-  async create(eventUuid: string, query: CreateEmailDto) {
-    return await this.prisma.$transaction(async (tx) => {
+  async create(
+    eventUuid: string,
+    query: CreateEmailDto,
+  ): Promise<EmailResponseDto> {
+    return this.prisma.$transaction(async (tx) => {
       const event = await tx.event.findUnique({
         where: { uuid: eventUuid },
         select: { uuid: true },
@@ -58,11 +63,17 @@ export class EmailsService {
         name: emailTemplate.name,
         content: emailTemplate.content,
         trigger: emailTemplate.trigger,
+        eventId: emailTemplate.eventUuid,
+        createdAt: emailTemplate.createdAt.toISOString(),
+        updatedAt: emailTemplate.updatedAt.toISOString(),
       };
     });
   }
 
-  async findAll(eventUuid: string, query: EmailListingDto) {
+  async findAll(
+    eventUuid: string,
+    query: EmailListingDto,
+  ): Promise<PageDto<EmailListElementDto>> {
     const event = await this.prisma.event.findUnique({
       where: { uuid: eventUuid },
     });
@@ -143,7 +154,10 @@ export class EmailsService {
     return new PageDto(data, meta);
   }
 
-  async findOne(eventUuid: string, emailUuid: string) {
+  async findOne(
+    eventUuid: string,
+    emailUuid: string,
+  ): Promise<EmailCompleteElement> {
     const emailTemplate = await this.prisma.emailTemplate.findFirst({
       where: {
         uuid: emailUuid,
@@ -190,5 +204,70 @@ export class EmailsService {
     };
 
     return formattedResponse;
+  }
+
+  async update(
+    eventUuid: string,
+    emailUuid: string,
+    query: UpdateEmailDto,
+  ): Promise<EmailResponseDto> {
+    return this.prisma.$transaction(async (tx) => {
+      const existingEmail = await tx.emailTemplate.findFirst({
+        where: {
+          uuid: emailUuid,
+          eventUuid,
+        },
+        select: { uuid: true },
+      });
+      if (existingEmail == null) {
+        throw new NotFoundException("Email template or event does not exist");
+      }
+
+      const emailTemplate = await tx.emailTemplate.update({
+        where: {
+          uuid: emailUuid,
+        },
+        data: {
+          name: query.name,
+          content: query.content,
+          trigger: query.trigger,
+          triggerValue: query.triggerValue,
+          triggerValue2: query.triggerValue2,
+          order: query.order,
+          formUuid: query.formId,
+        },
+      });
+
+      return {
+        id: emailTemplate.uuid,
+        name: emailTemplate.name,
+        content: emailTemplate.content,
+        trigger: emailTemplate.trigger,
+        eventId: emailTemplate.eventUuid,
+        createdAt: emailTemplate.createdAt.toISOString(),
+        updatedAt: emailTemplate.updatedAt.toISOString(),
+      };
+    });
+  }
+
+  async delete(eventUuid: string, emailUuid: string): Promise<void> {
+    await this.prisma.$transaction(async (tx) => {
+      const existingEmail = await tx.emailTemplate.findFirst({
+        where: {
+          uuid: emailUuid,
+          eventUuid,
+        },
+        select: { uuid: true },
+      });
+      if (existingEmail == null) {
+        throw new NotFoundException("Email template or event does not exist");
+      }
+
+      await tx.emailTemplate.delete({
+        where: {
+          uuid: emailUuid,
+        },
+      });
+    });
   }
 }

--- a/src/emails/emails.service.ts
+++ b/src/emails/emails.service.ts
@@ -4,9 +4,14 @@ import { parseSortInput } from "src/common/utils/prisma.utility";
 import { EmailStatus } from "src/generated/prisma/enums";
 import { PrismaService } from "src/prisma/prisma.service";
 
-import { BadRequestException, Injectable } from "@nestjs/common";
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from "@nestjs/common";
 
 import { CreateEmailDto } from "./dto/create-email.dto";
+import { EmailCompleteElement } from "./dto/email-complete-element.dto";
 import { EmailListElementDto } from "./dto/email-list-element.dto";
 import { EmailListingDto } from "./dto/email-listing.dto";
 
@@ -18,6 +23,7 @@ export class EmailsService {
     return await this.prisma.$transaction(async (tx) => {
       const event = await tx.event.findUnique({
         where: { uuid: eventUuid },
+        select: { uuid: true },
       });
       if (event == null) {
         throw new BadRequestException(`Event with id: ${eventUuid} not found`);
@@ -125,8 +131,8 @@ export class EmailsService {
         eventId: record.eventUuid,
         name: record.name,
         trigger: record.trigger,
-        triggerValue: "",
-        triggerValue2: "",
+        triggerValue: record.triggerValue,
+        triggerValue2: record.triggerValue2,
         createdAt: record.createdAt.toISOString(),
         updatedAt: record.updatedAt.toISOString(),
         meta: counts,
@@ -135,5 +141,54 @@ export class EmailsService {
 
     const meta = new PageMetaDto({ itemCount, pageOptionsDto: query });
     return new PageDto(data, meta);
+  }
+
+  async findOne(eventUuid: string, emailUuid: string) {
+    const emailTemplate = await this.prisma.emailTemplate.findFirst({
+      where: {
+        uuid: emailUuid,
+        eventUuid,
+      },
+      include: {
+        participantEmails: {
+          include: {
+            participant: true,
+          },
+        },
+      },
+    });
+
+    if (emailTemplate === null) {
+      throw new NotFoundException("Email not found");
+    }
+
+    const formattedResponse: EmailCompleteElement = {
+      id: emailTemplate.uuid,
+      eventId: emailTemplate.eventUuid,
+      name: emailTemplate.name,
+      content: emailTemplate.content,
+      trigger: emailTemplate.trigger,
+      triggerValue: emailTemplate.triggerValue,
+      triggerValue2: emailTemplate.triggerValue2,
+      formId: emailTemplate.formUuid,
+      order: emailTemplate.order,
+      createdAt: emailTemplate.createdAt.toISOString(),
+      updatedAt: emailTemplate.updatedAt.toISOString(),
+      participants: emailTemplate.participantEmails
+        .filter((pivot) => pivot.participant !== null)
+        .map((pivot) => ({
+          id: pivot.participant?.uuid,
+          email: pivot.participant?.email,
+          createdAt: pivot.participant?.createdAt.toISOString(),
+          updatedAt: pivot.participant?.updatedAt.toISOString(),
+          meta: {
+            pivot_status: pivot.status,
+            pivot_send_at: pivot.sendAt.toISOString(),
+            pivot_send_by: pivot.sendBy,
+          },
+        })),
+    };
+
+    return formattedResponse;
   }
 }

--- a/src/emails/emails.service.ts
+++ b/src/emails/emails.service.ts
@@ -1,8 +1,14 @@
+import { PageMetaDto } from "src/common/dto/page-meta.dto";
+import { PageDto } from "src/common/dto/page.dto";
+import { parseSortInput } from "src/common/utils/prisma.utility";
+import { EmailStatus } from "src/generated/prisma/enums";
 import { PrismaService } from "src/prisma/prisma.service";
 
 import { BadRequestException, Injectable } from "@nestjs/common";
 
 import { CreateEmailDto } from "./dto/create-email.dto";
+import { EmailListElementDto } from "./dto/email-list-element.dto";
+import { EmailListingDto } from "./dto/email-listing.dto";
 
 @Injectable()
 export class EmailsService {
@@ -48,5 +54,86 @@ export class EmailsService {
         trigger: emailTemplate.trigger,
       };
     });
+  }
+
+  async findAll(eventUuid: string, query: EmailListingDto) {
+    const event = await this.prisma.event.findUnique({
+      where: { uuid: eventUuid },
+    });
+    if (event == null) {
+      throw new BadRequestException(`Event with id: ${eventUuid} not found`);
+    }
+
+    const { skip, take, sort, trigger } = query;
+    const orderBy = parseSortInput(sort, ["createdAt", "updatedAt", "name"]);
+    const where = {
+      eventUuid,
+      trigger,
+    };
+
+    if (orderBy.length === 0) {
+      orderBy.push({ createdAt: "desc" });
+    }
+
+    const [itemCount, templates] = await this.prisma.$transaction([
+      this.prisma.emailTemplate.count({ where }),
+      this.prisma.emailTemplate.findMany({
+        where,
+        take,
+        skip,
+        orderBy,
+        select: {
+          uuid: true,
+          eventUuid: true,
+          name: true,
+          trigger: true,
+          triggerValue: true,
+          triggerValue2: true,
+          createdAt: true,
+          updatedAt: true,
+          participantEmails: {
+            select: { status: true },
+          },
+        },
+      }),
+    ]);
+
+    const data: EmailListElementDto[] = templates.map((record) => {
+      const counts = record.participantEmails.reduce(
+        (accumulator, email) => {
+          switch (email.status) {
+            case EmailStatus.failed: {
+              accumulator.failedCount++;
+              break;
+            }
+            case EmailStatus.pending: {
+              accumulator.pendingCount++;
+              break;
+            }
+            case EmailStatus.sent: {
+              accumulator.sentCount++;
+              break;
+            }
+          }
+          return accumulator;
+        },
+        { failedCount: 0, pendingCount: 0, sentCount: 0 },
+      );
+
+      return {
+        id: record.uuid,
+        eventId: record.eventUuid,
+        name: record.name,
+        trigger: record.trigger,
+        triggerValue: "",
+        triggerValue2: "",
+        createdAt: record.createdAt.toISOString(),
+        updatedAt: record.updatedAt.toISOString(),
+        meta: counts,
+      };
+    });
+
+    const meta = new PageMetaDto({ itemCount, pageOptionsDto: query });
+    return new PageDto(data, meta);
   }
 }


### PR DESCRIPTION
Tak jak nakazano, zrobione endpointy:
GET /events/:eventId/emails
POST /events/:eventId/emails
GET /events/:eventId/emails/:id
PATCH /events/:eventId/emails/:id
DELETE /events/:eventId/emails/:id

Swagger, testy, etc...

Rzeczy na które można zwrócić uwagę:
W GET /events/:eventId/emails, zliczanie statusów emaili odbywa się na backendzie a nie po stronie bazy danych, jeśli powodowałoby to problemy wydajnościowe, trzeba będzie napisać własną kwerendę sql.

