### PR TITLE
Feat/public block get

### DIFF
--- a/src/blocks/block-public.controller.spec.ts
+++ b/src/blocks/block-public.controller.spec.ts
@@ -1,0 +1,27 @@
+import { Test } from "@nestjs/testing";
+import type { TestingModule } from "@nestjs/testing";
+
+import { BlocksPublicController } from "./block-public.controller";
+import { BlocksService } from "./blocks.service";
+
+describe("BlockPublicController", () => {
+  let controller: BlocksPublicController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [BlocksPublicController],
+      providers: [
+        {
+          provide: BlocksService,
+          useValue: {},
+        },
+      ],
+    }).compile();
+
+    controller = module.get<BlocksPublicController>(BlocksPublicController);
+  });
+
+  it("should be defined", () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/blocks/block-public.controller.ts
+++ b/src/blocks/block-public.controller.ts
@@ -1,6 +1,7 @@
 import { Controller, Get, Param, ParseUUIDPipe } from "@nestjs/common";
 import {
-  ApiCreatedResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
   ApiOperation,
   ApiParam,
   ApiTags,
@@ -18,11 +19,31 @@ export class BlocksPublicController {
   @ApiOperation({ summary: "Get block tree" })
   @ApiParam({ name: "eventSlug", description: "Slug of the event" })
   @ApiParam({ name: "attributeUuid", description: "UUID of the attribute" })
-  @ApiCreatedResponse({ description: "Block tree", type: Block })
+  @ApiOkResponse({ description: "Block tree", type: Block })
+  @ApiNotFoundResponse({ description: "Block not found" })
   async getBlockTree(
     @Param("eventSlug") eventSlug: string,
     @Param("attributeUuid", ParseUUIDPipe) attributeUuid: string,
   ): Promise<Block> {
     return await this.blocksService.getBlockTree(eventSlug, attributeUuid);
+  }
+
+  @Get(":blockUuid")
+  @ApiOperation({ summary: "Get a list of block participants" })
+  @ApiParam({ name: "eventSlug", description: "Slug of the event" })
+  @ApiParam({ name: "attributeUuid", description: "UUID of the attribute" })
+  @ApiParam({ name: "blockUuid", description: "UUID of the block" })
+  @ApiOkResponse({ description: "A list of block participants", type: Block })
+  @ApiNotFoundResponse({ description: "Block not found" })
+  async getBlockParticipants(
+    @Param("eventSlug") eventSlug: string,
+    @Param("attributeUuid", ParseUUIDPipe) attributeUuid: string,
+    @Param("blockUuid", ParseUUIDPipe) blockUuid: string,
+  ) {
+    return await this.blocksService.getBlockParticipants(
+      eventSlug,
+      attributeUuid,
+      blockUuid,
+    );
   }
 }

--- a/src/blocks/block-public.controller.ts
+++ b/src/blocks/block-public.controller.ts
@@ -8,6 +8,7 @@ import {
 } from "@nestjs/swagger";
 
 import { BlocksService } from "./blocks.service";
+import { BlockWithParticipantCount } from "./dto/block-with-participant-count.dto";
 import { Block } from "./entities/block.entity";
 
 @ApiTags("Public")
@@ -19,12 +20,15 @@ export class BlocksPublicController {
   @ApiOperation({ summary: "Get block tree" })
   @ApiParam({ name: "eventSlug", description: "Slug of the event" })
   @ApiParam({ name: "attributeUuid", description: "UUID of the attribute" })
-  @ApiOkResponse({ description: "Block tree", type: Block })
+  @ApiOkResponse({
+    description: "Block tree",
+    type: BlockWithParticipantCount,
+  })
   @ApiNotFoundResponse({ description: "Block not found" })
   async getBlockTree(
     @Param("eventSlug") eventSlug: string,
     @Param("attributeUuid", ParseUUIDPipe) attributeUuid: string,
-  ): Promise<Block> {
+  ): Promise<BlockWithParticipantCount> {
     return await this.blocksService.getBlockTree(eventSlug, attributeUuid);
   }
 

--- a/src/blocks/block-public.controller.ts
+++ b/src/blocks/block-public.controller.ts
@@ -1,0 +1,28 @@
+import { Controller, Get, Param, ParseUUIDPipe } from "@nestjs/common";
+import {
+  ApiCreatedResponse,
+  ApiOperation,
+  ApiParam,
+  ApiTags,
+} from "@nestjs/swagger";
+
+import { BlocksService } from "./blocks.service";
+import { Block } from "./entities/block.entity";
+
+@ApiTags("Public")
+@Controller("public/events/:eventSlug/attributes/:attributeUuid/blocks")
+export class BlocksPublicController {
+  constructor(private readonly blocksService: BlocksService) {}
+
+  @Get("")
+  @ApiOperation({ summary: "Get block tree" })
+  @ApiParam({ name: "eventSlug", description: "Slug of the event" })
+  @ApiParam({ name: "attributeUuid", description: "UUID of the attribute" })
+  @ApiCreatedResponse({ description: "Block tree", type: Block })
+  async getBlockTree(
+    @Param("eventSlug") eventSlug: string,
+    @Param("attributeUuid", ParseUUIDPipe) attributeUuid: string,
+  ): Promise<Block> {
+    return await this.blocksService.getBlockTree(eventSlug, attributeUuid);
+  }
+}

--- a/src/blocks/blocks.int.spec.ts
+++ b/src/blocks/blocks.int.spec.ts
@@ -4,6 +4,7 @@ import { NotFoundException } from "@nestjs/common";
 import type { TestingModule } from "@nestjs/testing";
 import { Test } from "@nestjs/testing";
 
+import { BlocksPublicController } from "./block-public.controller";
 import { BlocksController } from "./blocks.controller";
 import { BlocksService } from "./blocks.service";
 import type { CreateBlockDto } from "./dto/create-block.dto";
@@ -12,6 +13,8 @@ import type { Block } from "./entities/block.entity";
 
 describe("Blocks Integration", () => {
   let blocksController: BlocksController;
+  let blocksPublicController: BlocksPublicController;
+  let blocksService: BlocksService;
 
   const mockPrismaService = {
     block: {
@@ -23,8 +26,14 @@ describe("Blocks Integration", () => {
       delete: jest.fn(),
       count: jest.fn(),
     },
+    participantAttribute: {
+      count: jest.fn(),
+    },
     attribute: {
       findFirst: jest.fn(),
+    },
+    event: {
+      findUnique: jest.fn(),
     },
     $transaction: jest.fn(),
   };
@@ -35,9 +44,9 @@ describe("Blocks Integration", () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
+      controllers: [BlocksController, BlocksPublicController],
       providers: [
         BlocksService,
-        BlocksController,
         {
           provide: PrismaService,
           useValue: mockPrismaService,
@@ -46,6 +55,10 @@ describe("Blocks Integration", () => {
     }).compile();
 
     blocksController = module.get<BlocksController>(BlocksController);
+    blocksService = module.get<BlocksService>(BlocksService);
+    blocksPublicController = module.get<BlocksPublicController>(
+      BlocksPublicController,
+    );
 
     jest.clearAllMocks();
   });
@@ -213,6 +226,165 @@ describe("Blocks Integration", () => {
       expect(mockPrismaService.block.delete).toHaveBeenCalledWith({
         where: { uuid: blockId },
       });
+    });
+  });
+
+  describe("getBlockTree", () => {
+    const eventSlug = "sample-event";
+    const eventUuid = "event-uuid";
+
+    const rootBlock = {
+      uuid: "root-block",
+      name: "Root",
+      parentUuid: null,
+      attributeUuid: "attr-uuid",
+      isRootBlock: true,
+      capacity: null,
+      order: 0,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    const childBlock = {
+      uuid: "child-block",
+      name: "Child",
+      parentUuid: "root-block",
+      attributeUuid: "attr-uuid",
+      isRootBlock: false,
+      capacity: 10,
+      order: 1,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    const nestedBlock = {
+      uuid: "nested-block",
+      name: "Nested",
+      parentUuid: "child-block",
+      attributeUuid: "attr-uuid",
+      isRootBlock: false,
+      capacity: 5,
+      order: 1,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    it("should return block tree with participant counts", async () => {
+      mockPrismaService.event.findUnique.mockResolvedValue({
+        uuid: eventUuid,
+        slug: eventSlug,
+      });
+
+      mockPrismaService.block.findMany.mockResolvedValue([
+        rootBlock,
+        childBlock,
+        nestedBlock,
+      ]);
+
+      jest
+        .spyOn(blocksService, "getBlockParticipantsCount")
+        .mockImplementation(async (blockUuid: string) => {
+          if (blockUuid === "child-block") {
+            return await new Promise((resolve) => {
+              resolve(3);
+            });
+          }
+          if (blockUuid === "nested-block") {
+            return await new Promise((resolve) => {
+              resolve(1);
+            });
+          }
+          return await new Promise((resolve) => {
+            resolve(0);
+          });
+        });
+
+      const result = await blocksPublicController.getBlockTree(
+        eventSlug,
+        "attr-uuid",
+      );
+
+      expect(mockPrismaService.event.findUnique).toHaveBeenCalledWith({
+        where: { slug: eventSlug },
+      });
+
+      expect(mockPrismaService.block.findMany).toHaveBeenCalledWith({
+        where: {
+          attributeUuid: "attr-uuid",
+          attribute: {
+            eventUuid,
+          },
+        },
+      });
+
+      expect(result).toMatchObject({
+        uuid: "root-block",
+        children: [
+          {
+            uuid: "child-block",
+            blockParticipantCount: 3,
+            children: [
+              {
+                uuid: "nested-block",
+                blockParticipantCount: 1,
+                children: [],
+              },
+            ],
+          },
+        ],
+      });
+    });
+
+    it("should throw when root block does not exist", async () => {
+      mockPrismaService.event.findUnique.mockResolvedValue({
+        uuid: eventUuid,
+        slug: eventSlug,
+      });
+
+      mockPrismaService.block.findMany.mockResolvedValue([
+        {
+          ...childBlock,
+          isRootBlock: false,
+        },
+      ]);
+
+      await expect(
+        blocksPublicController.getBlockTree(eventSlug, "attr-uuid"),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it("should return root block with empty children array", async () => {
+      mockPrismaService.event.findUnique.mockResolvedValue({
+        uuid: eventUuid,
+        slug: eventSlug,
+      });
+
+      mockPrismaService.block.findMany.mockResolvedValue([rootBlock]);
+
+      const result = await blocksPublicController.getBlockTree(
+        eventSlug,
+        "attr-uuid",
+      );
+
+      expect(result).toMatchObject({
+        uuid: "root-block",
+        children: [],
+      });
+    });
+
+    it("should not calculate participant count for blocks without capacity", async () => {
+      mockPrismaService.event.findUnique.mockResolvedValue({
+        uuid: eventUuid,
+        slug: eventSlug,
+      });
+
+      mockPrismaService.block.findMany.mockResolvedValue([rootBlock]);
+
+      const countSpy = jest.spyOn(blocksService, "getBlockParticipantsCount");
+
+      await blocksService.getBlockTree(eventSlug, "attr-uuid");
+
+      expect(countSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/blocks/blocks.int.spec.ts
+++ b/src/blocks/blocks.int.spec.ts
@@ -1,3 +1,4 @@
+import { ParticipantsService } from "src/participants/participants.service";
 import { PrismaService } from "src/prisma/prisma.service";
 
 import { NotFoundException } from "@nestjs/common";
@@ -38,6 +39,10 @@ describe("Blocks Integration", () => {
     $transaction: jest.fn(),
   };
 
+  const mockParticipantService = {
+    findAll: jest.fn(),
+  };
+
   const eventId = "3fa85f64-5717-4562-b3fc-2c963f66afa6";
   const attributeId = "3fa85f64-5717-4562-b3fc-2c963f66afa7";
   const blockId = "3fa85f64-5717-4562-b3fc-2c963f66afa8";
@@ -47,6 +52,10 @@ describe("Blocks Integration", () => {
       controllers: [BlocksController, BlocksPublicController],
       providers: [
         BlocksService,
+        {
+          provide: ParticipantsService,
+          useValue: mockParticipantService,
+        },
         {
           provide: PrismaService,
           useValue: mockPrismaService,
@@ -385,6 +394,148 @@ describe("Blocks Integration", () => {
       await blocksService.getBlockTree(eventSlug, "attr-uuid");
 
       expect(countSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("getBlockParticipants", () => {
+    it("throws if event does not exist", async () => {
+      mockPrismaService.event.findUnique.mockResolvedValue(null);
+
+      await expect(
+        blocksPublicController.getBlockParticipants(
+          "event-slug",
+          "attr-uuid",
+          "block-uuid",
+        ),
+      ).rejects.toThrow(NotFoundException);
+
+      expect(mockPrismaService.block.findUnique).not.toHaveBeenCalled();
+    });
+
+    it("throws if block does not exist", async () => {
+      mockPrismaService.event.findUnique.mockResolvedValue({
+        uuid: "event-uuid",
+      });
+      mockPrismaService.block.findUnique.mockResolvedValue(null);
+
+      await expect(
+        blocksPublicController.getBlockParticipants(
+          "event-slug",
+          "attr-uuid",
+          "block-uuid",
+        ),
+      ).rejects.toThrow(NotFoundException);
+
+      expect(mockParticipantService.findAll).not.toHaveBeenCalled();
+    });
+
+    it("throws if block attribute is missing", async () => {
+      mockPrismaService.event.findUnique.mockResolvedValue({
+        uuid: "event-uuid",
+      });
+
+      mockPrismaService.block.findUnique.mockResolvedValue({
+        uuid: "block-uuid",
+        attribute: null,
+      });
+
+      await expect(
+        blocksPublicController.getBlockParticipants(
+          "event-slug",
+          "attr-uuid",
+          "block-uuid",
+        ),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it("returns participants without bonus attributes", async () => {
+      mockPrismaService.event.findUnique.mockResolvedValue({
+        uuid: "event-uuid",
+      });
+
+      mockPrismaService.block.findUnique.mockResolvedValue({
+        uuid: "block-uuid",
+        attribute: { config: null },
+      });
+
+      mockParticipantService.findAll.mockResolvedValue(["p1", "p2"]);
+
+      const result = await blocksPublicController.getBlockParticipants(
+        "event-slug",
+        "attr-uuid",
+        "block-uuid",
+      );
+
+      expect(mockParticipantService.findAll).toHaveBeenCalledWith(
+        "event-uuid",
+        {
+          skip: 0,
+          filters: { attributeUuid: "block-uuid" },
+          bonusAttributes: "",
+        },
+      );
+
+      expect(result).toEqual(["p1", "p2"]);
+    });
+
+    it("extracts participantFields from config", async () => {
+      mockPrismaService.event.findUnique.mockResolvedValue({
+        uuid: "event-uuid",
+      });
+
+      mockPrismaService.block.findUnique.mockResolvedValue({
+        uuid: "block-uuid",
+        attribute: {
+          config: {
+            participantFields: ["a", "b", "c"],
+          },
+        },
+      });
+
+      mockParticipantService.findAll.mockResolvedValue(["p1"]);
+
+      await blocksPublicController.getBlockParticipants(
+        "event-slug",
+        "attr-uuid",
+        "block-uuid",
+      );
+
+      expect(mockParticipantService.findAll).toHaveBeenCalledWith(
+        "event-uuid",
+        expect.objectContaining({
+          bonusAttributes: "a,b,c",
+        }),
+      );
+    });
+
+    it("ignores invalid participantFields", async () => {
+      mockPrismaService.event.findUnique.mockResolvedValue({
+        uuid: "event-uuid",
+      });
+
+      mockPrismaService.block.findUnique.mockResolvedValue({
+        uuid: "block-uuid",
+        attribute: {
+          config: {
+            participantFields: ["valid", 123, null],
+          },
+        },
+      });
+
+      mockParticipantService.findAll.mockResolvedValue([]);
+
+      await blocksPublicController.getBlockParticipants(
+        "event-slug",
+        "attr-uuid",
+        "block-uuid",
+      );
+
+      expect(mockParticipantService.findAll).toHaveBeenCalledWith(
+        "event-uuid",
+        expect.objectContaining({
+          bonusAttributes: "",
+        }),
+      );
     });
   });
 });

--- a/src/blocks/blocks.module.ts
+++ b/src/blocks/blocks.module.ts
@@ -1,10 +1,11 @@
 import { Module } from "@nestjs/common";
 
+import { BlocksPublicController } from "./block-public.controller";
 import { BlocksController } from "./blocks.controller";
 import { BlocksService } from "./blocks.service";
 
 @Module({
-  controllers: [BlocksController],
+  controllers: [BlocksController, BlocksPublicController],
   providers: [BlocksService],
   exports: [BlocksService],
 })

--- a/src/blocks/blocks.module.ts
+++ b/src/blocks/blocks.module.ts
@@ -1,3 +1,5 @@
+import { ParticipantsModule } from "src/participants/participants.module";
+
 import { Module } from "@nestjs/common";
 
 import { BlocksPublicController } from "./block-public.controller";
@@ -8,5 +10,6 @@ import { BlocksService } from "./blocks.service";
   controllers: [BlocksController, BlocksPublicController],
   providers: [BlocksService],
   exports: [BlocksService],
+  imports: [ParticipantsModule],
 })
 export class BlocksModule {}

--- a/src/blocks/blocks.service.spec.ts
+++ b/src/blocks/blocks.service.spec.ts
@@ -1,3 +1,4 @@
+import { ParticipantsService } from "src/participants/participants.service";
 import { PrismaService } from "src/prisma/prisma.service";
 
 import type { TestingModule } from "@nestjs/testing";
@@ -12,6 +13,10 @@ describe("BlocksService", () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         BlocksService,
+        {
+          provide: ParticipantsService,
+          useValue: {},
+        },
         {
           provide: PrismaService,
           useValue: {},

--- a/src/blocks/blocks.service.ts
+++ b/src/blocks/blocks.service.ts
@@ -262,10 +262,66 @@ export class BlocksService {
     }
 
     if (block.capacity === null) {
-      return true;
+      return false;
     }
 
     const count = await this.getBlockParticipantsCount(blockId, tx);
     return count < block.capacity;
+  }
+
+  async getBlockTree(eventSlug: string, attributeUuid: string): Promise<Block> {
+    const event = await this.prisma.event.findUnique({
+      where: { slug: eventSlug },
+    });
+
+    const blocks = await this.prisma.block.findMany({
+      where: {
+        attributeUuid,
+        attribute: {
+          eventUuid: event?.uuid,
+        },
+      },
+    });
+
+    const blockMap = new Map<
+      string,
+      Block & { blockParticipantCount?: number; children: Block[] }
+    >();
+
+    for (const block of blocks) {
+      let blockParticipantCount: number | undefined;
+
+      if (block.capacity !== null) {
+        blockParticipantCount = await this.getBlockParticipantsCount(
+          block.uuid,
+        );
+      }
+
+      blockMap.set(block.uuid, {
+        ...block,
+        blockParticipantCount,
+        children: [],
+      });
+    }
+
+    let root: Block | null = null;
+
+    for (const block of blockMap.values()) {
+      if (block.isRootBlock) {
+        root = block;
+      }
+
+      if (block.parentUuid !== null) {
+        blockMap.get(block.parentUuid)?.children.push(block);
+      }
+    }
+
+    if (root === null) {
+      throw new NotFoundException(
+        `Attribute with UUID ${attributeUuid} doesn't have a block tree`,
+      );
+    }
+
+    return root;
   }
 }

--- a/src/blocks/blocks.service.ts
+++ b/src/blocks/blocks.service.ts
@@ -1,4 +1,5 @@
 import { Prisma } from "src/generated/prisma/client";
+import { ParticipantsService } from "src/participants/participants.service";
 import { PrismaService } from "src/prisma/prisma.service";
 
 import {
@@ -13,7 +14,10 @@ import { Block } from "./entities/block.entity";
 
 @Injectable()
 export class BlocksService {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly participantsService: ParticipantsService,
+  ) {}
 
   private getClient(tx?: Prisma.TransactionClient) {
     return tx ?? this.prisma;
@@ -323,5 +327,60 @@ export class BlocksService {
     }
 
     return root;
+  }
+
+  async getBlockParticipants(
+    eventSlug: string,
+    attributeUuid: string,
+    blockUuid: string,
+  ) {
+    const event = await this.prisma.event.findUnique({
+      where: { slug: eventSlug },
+      select: { uuid: true },
+    });
+
+    if (event === null) {
+      throw new NotFoundException(`Event with slug ${eventSlug} doesn't exist`);
+    }
+
+    const block = await this.prisma.block.findUnique({
+      where: {
+        uuid: blockUuid,
+        attributeUuid,
+        attribute: {
+          eventUuid: event.uuid,
+        },
+      },
+      select: { uuid: true, attribute: { select: { config: true } } },
+    });
+
+    if (block?.attribute == null) {
+      throw new NotFoundException(`Block with UUID ${blockUuid} doesn't exist`);
+    }
+
+    const config = block.attribute.config;
+
+    let bonusAttributes = "";
+
+    if (config !== null && typeof config === "object") {
+      const configJson = config as Prisma.JsonObject;
+
+      const participantFields: unknown = configJson.participantFields;
+
+      if (
+        Array.isArray(participantFields) &&
+        participantFields.every((item) => typeof item === "string")
+      ) {
+        bonusAttributes = participantFields.join(",");
+      }
+    }
+
+    const participants = await this.participantsService.findAll(event.uuid, {
+      skip: 0,
+      filters: { attributeUuid: blockUuid },
+      bonusAttributes,
+    });
+
+    return participants;
   }
 }

--- a/src/blocks/dto/block-with-participant-count.dto.ts
+++ b/src/blocks/dto/block-with-participant-count.dto.ts
@@ -1,0 +1,11 @@
+import { ApiPropertyOptional } from "@nestjs/swagger";
+
+import { Block } from "../entities/block.entity";
+
+export class BlockWithParticipantCount extends Block {
+  @ApiPropertyOptional()
+  blockParticipantCount?: number;
+
+  @ApiPropertyOptional({ isArray: true, type: () => BlockWithParticipantCount })
+  declare children?: BlockWithParticipantCount[];
+}


### PR DESCRIPTION
Dodałem dwa publiczne endpointy:
- `public/events/:eventSlug/attributes/:attributeUuid/blocks` - zwraca drzewo bloków
- `public/events/:eventSlug/attributes/:attributeUuid/blocks/:blockId` - zwracam uczestników danego bolu wraz z atrybutami, których UUID jest w konfigu

Zmieniłem też metodę `canSignInToBlock`, żeby zwracała `false`, kiedy `capacity === null`. Tu pytanie, czy tak miało być i popsułem, czy naprawiłem?


Closes #61 