### PR TITLE
Feat/password reset and authaccesstoken table refactor

### DIFF
--- a/prisma/migrations/20260512193257_auth_access_token_table_refactor/migration.sql
+++ b/prisma/migrations/20260512193257_auth_access_token_table_refactor/migration.sql
@@ -1,0 +1,35 @@
+/*
+  Warnings:
+
+  - You are about to drop the `AuthAccessTokens` table. If the table is not empty, all the data it contains will be lost.
+  - Made the column `eventUuid` on table `EmailTemplates` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- DropForeignKey
+ALTER TABLE "AuthAccessTokens" DROP CONSTRAINT "AuthAccessTokens_tokenable_id_fkey";
+
+-- AlterTable
+ALTER TABLE "EmailTemplates" ALTER COLUMN "eventUuid" SET NOT NULL;
+
+-- DropTable
+DROP TABLE "AuthAccessTokens";
+
+-- CreateTable
+CREATE TABLE "RefreshTokens" (
+    "uuid" UUID NOT NULL,
+    "adminUuid" UUID NOT NULL,
+    "token" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expires_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "RefreshTokens_pkey" PRIMARY KEY ("uuid")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RefreshTokens_token_key" ON "RefreshTokens"("token");
+
+-- CreateIndex
+CREATE INDEX "RefreshTokens_adminUuid_idx" ON "RefreshTokens"("adminUuid");
+
+-- AddForeignKey
+ALTER TABLE "RefreshTokens" ADD CONSTRAINT "RefreshTokens_adminUuid_fkey" FOREIGN KEY ("adminUuid") REFERENCES "Admins"("uuid") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20260513172904_password_reset_token_table/migration.sql
+++ b/prisma/migrations/20260513172904_password_reset_token_table/migration.sql
@@ -1,0 +1,16 @@
+-- CreateTable
+CREATE TABLE "PasswordResetTokens" (
+    "uuid" UUID NOT NULL,
+    "adminUuid" UUID NOT NULL,
+    "token" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expires_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "PasswordResetTokens_pkey" PRIMARY KEY ("uuid")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PasswordResetTokens_token_key" ON "PasswordResetTokens"("token");
+
+-- AddForeignKey
+ALTER TABLE "PasswordResetTokens" ADD CONSTRAINT "PasswordResetTokens_adminUuid_fkey" FOREIGN KEY ("adminUuid") REFERENCES "Admins"("uuid") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -34,7 +34,7 @@ model Admin {
 
   events           Event[]           @relation("Organizer")
   permissions      EventPermission[]
-  authAccessTokens AuthAccessToken[]
+  refreshToken     RefreshToken[]
 
   @@map("Admins")
 }
@@ -320,19 +320,15 @@ model ParticipantAttributeLog {
   @@map("ParticipantsAttributesLogs")
 }
 
-model AuthAccessToken {
-  id          Int       @id @default(autoincrement())
-  tokenableId String    @map("tokenable_id") @db.Uuid
-  type        String
-  name        String?
+model RefreshToken {
+  uuid        String    @id @default(uuid()) @db.Uuid
+  adminUuid   String    @db.Uuid
   token       String    @unique
-  abilities   String
   createdAt   DateTime  @default(now()) @map("created_at")
-  updatedAt   DateTime  @map("updated_at")
-  lastUsedAt  DateTime? @map("last_used_at")
   expiresAt   DateTime  @map("expires_at")
 
-  admin Admin @relation(fields: [tokenableId], references: [uuid], onDelete: Cascade)
+  admin Admin @relation(fields: [adminUuid], references: [uuid], onDelete: Cascade)
 
-  @@map("AuthAccessTokens")
+  @@map("RefreshTokens")
+  @@index(fields: [adminUuid])
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -35,6 +35,7 @@ model Admin {
   events           Event[]           @relation("Organizer")
   permissions      EventPermission[]
   refreshToken     RefreshToken[]
+  passwordResetToken PasswordResetToken[]
 
   @@map("Admins")
 }
@@ -331,4 +332,16 @@ model RefreshToken {
 
   @@map("RefreshTokens")
   @@index(fields: [adminUuid])
+}
+
+model PasswordResetToken {
+  uuid      String @id @default(uuid()) @db.Uuid
+  adminUuid String @db.Uuid
+  token     String @unique
+  createdAt   DateTime  @default(now()) @map("created_at")
+  expiresAt   DateTime  @map("expires_at")
+
+  admin Admin @relation(fields: [adminUuid], references: [uuid], onDelete: Cascade)
+
+  @@map("PasswordResetTokens")
 }

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -10,6 +10,7 @@ import {
   UseGuards,
 } from "@nestjs/common";
 import {
+  ApiBadRequestResponse,
   ApiBearerAuth,
   ApiConflictResponse,
   ApiCreatedResponse,
@@ -28,6 +29,7 @@ import { TokenResponseDto } from "./dto/token-response.dto";
 import { JwtAuthGuard } from "./jwt-auth.guard";
 import { AuthUser } from "./jwt.strategy";
 import { ForgotPasswordDto } from "./dto/forgot-password.dto";
+import { ResetPasswordDto } from "./dto/reset-password.dto";
 
 @ApiTags("Auth")
 @Controller("auth")
@@ -91,11 +93,31 @@ export class AuthController {
   @ApiOkResponse({
     description: "If the email exists, a reset link has been sent",
   })
+  @ApiBadRequestResponse({
+    description: "Validation error (invalid email)",
+  })
   @ApiOperation({ summary: "Generate password reset token and send an email" })
   async forgotPassword(@Body() body: ForgotPasswordDto) {
     await this.authService.forgotPassword(body.email);
     return {
       message: "If the email exists, a reset link has been sent",
+    };
+  }
+
+  @Post("reset-password")
+  @HttpCode(HttpStatus.OK)
+  @ApiBadRequestResponse({
+    description:
+      "Validation error (password didn't meet criteria, token does not exist/expired)",
+  })
+  @ApiOkResponse({
+    description: "Password has been reset",
+  })
+  @ApiOperation({ summary: "Resets a password" })
+  async resetPassword(@Body() body: ResetPasswordDto) {
+    await this.authService.resetPassword(body.token, body.password);
+    return {
+      message: "Password has been reset",
     };
   }
 }

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -2,6 +2,8 @@ import {
   Body,
   Controller,
   Get,
+  HttpCode,
+  HttpStatus,
   Post,
   Request,
   UnauthorizedException,
@@ -25,6 +27,7 @@ import { RegisterDto } from "./dto/register.dto";
 import { TokenResponseDto } from "./dto/token-response.dto";
 import { JwtAuthGuard } from "./jwt-auth.guard";
 import { AuthUser } from "./jwt.strategy";
+import { ForgotPasswordDto } from "./dto/forgot-password.dto";
 
 @ApiTags("Auth")
 @Controller("auth")
@@ -81,5 +84,18 @@ export class AuthController {
       ...user
     } = request.user;
     return user;
+  }
+
+  @Post("forgot-password")
+  @HttpCode(HttpStatus.OK)
+  @ApiOkResponse({
+    description: "If the email exists, a reset link has been sent",
+  })
+  @ApiOperation({ summary: "Generate password reset token and send an email" })
+  async forgotPassword(@Body() body: ForgotPasswordDto) {
+    await this.authService.forgotPassword(body.email);
+    return {
+      message: "If the email exists, a reset link has been sent",
+    };
   }
 }

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -22,14 +22,14 @@ import {
 
 import { AuthService } from "./auth.service";
 import { AdminDto } from "./dto/auth-user.dto";
+import { ForgotPasswordDto } from "./dto/forgot-password.dto";
 import { LoginDto } from "./dto/login.dto";
 import { RefreshTokenDto } from "./dto/refresh-token.dto";
 import { RegisterDto } from "./dto/register.dto";
+import { ResetPasswordDto } from "./dto/reset-password.dto";
 import { TokenResponseDto } from "./dto/token-response.dto";
 import { JwtAuthGuard } from "./jwt-auth.guard";
 import { AuthUser } from "./jwt.strategy";
-import { ForgotPasswordDto } from "./dto/forgot-password.dto";
-import { ResetPasswordDto } from "./dto/reset-password.dto";
 
 @ApiTags("Auth")
 @Controller("auth")

--- a/src/auth/auth.int.spec.ts
+++ b/src/auth/auth.int.spec.ts
@@ -28,6 +28,7 @@ describe("AuthController integration tests", () => {
     validateUser: jest.fn(),
     login: jest.fn(),
     refreshTokens: jest.fn(),
+    forgotPassword: jest.fn(),
   };
 
   beforeEach(async () => {
@@ -111,6 +112,22 @@ describe("AuthController integration tests", () => {
       expect(result).toEqual({
         access_token: "new-at",
         refresh_token: "new-rt",
+      });
+    });
+  });
+
+  describe("forgotPassword", () => {
+    it("should call authService.forgotPassword and return default message", async () => {
+      const mockEmail = "abc@example.com";
+      mockAuthService.forgotPassword({ email: mockEmail });
+      mockAuthService.forgotPassword.mockResolvedValue(true);
+
+      const result = await controller.forgotPassword({
+        email: mockEmail,
+      });
+      expect(mockAuthService.forgotPassword).toHaveBeenCalledWith(mockEmail);
+      expect(result).toEqual({
+        message: "If the email exists, a reset link has been sent",
       });
     });
   });

--- a/src/auth/auth.int.spec.ts
+++ b/src/auth/auth.int.spec.ts
@@ -29,6 +29,7 @@ describe("AuthController integration tests", () => {
     login: jest.fn(),
     refreshTokens: jest.fn(),
     forgotPassword: jest.fn(),
+    resetPassword: jest.fn(),
   };
 
   beforeEach(async () => {
@@ -129,6 +130,24 @@ describe("AuthController integration tests", () => {
       expect(result).toEqual({
         message: "If the email exists, a reset link has been sent",
       });
+    });
+  });
+
+  describe("resetPassword", () => {
+    it("should call authService.resetPassword and return default message", async () => {
+      const dto = { token: "abc-token", password: "abc-password" };
+
+      mockAuthService.resetPassword.mockResolvedValue(true);
+
+      const result = await controller.resetPassword(dto);
+
+      expect(result).toEqual({
+        message: "Password has been reset",
+      });
+      expect(mockAuthService.resetPassword).toHaveBeenCalledWith(
+        dto.token,
+        dto.password,
+      );
     });
   });
 });

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -30,7 +30,7 @@ describe("AuthService", () => {
       findUnique: jest.fn(),
       create: jest.fn(),
     },
-    authAccessToken: {
+    refreshToken: {
       create: jest.fn(),
       findUnique: jest.fn(),
       delete: jest.fn(),
@@ -142,18 +142,17 @@ describe("AuthService", () => {
 
   describe("login", () => {
     it("should return access and refresh tokens (securely)", async () => {
-      mockPrisma.authAccessToken.create.mockResolvedValue({ id: 1 });
+      mockPrisma.refreshToken.create.mockResolvedValue({ id: 1 });
 
       const result = await service.login(mockAdmin);
 
       expect(mockJwtService.sign).toHaveBeenCalled();
 
-      expect(mockPrisma.authAccessToken.create).toHaveBeenCalledWith({
+      expect(mockPrisma.refreshToken.create).toHaveBeenCalledWith({
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         data: expect.objectContaining({
           // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
           token: expect.any(String),
-          type: "refresh_token",
         }),
       });
       expect(result).toHaveProperty("access_token");
@@ -162,7 +161,7 @@ describe("AuthService", () => {
 
       const storedToken =
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        mockPrisma.authAccessToken.create.mock.calls[0][0].data.token as string;
+        mockPrisma.refreshToken.create.mock.calls[0][0].data.token as string;
       const expectedHash = createHash("sha256")
         .update(result.refresh_token)
         .digest("hex");
@@ -175,13 +174,13 @@ describe("AuthService", () => {
       const plainToken = "valid-token";
       const hashedToken = createHash("sha256").update(plainToken).digest("hex");
       const storedToken = {
-        id: 1,
+        uuid: "3e19d992-2ea5-4ed3-9245-6691c41f4f06",
         token: hashedToken,
         expiresAt: new Date(Date.now() + 10_000),
         admin: mockAdmin,
       };
-      mockPrisma.authAccessToken.findUnique.mockResolvedValue(storedToken);
-      mockPrisma.authAccessToken.delete.mockResolvedValue(storedToken);
+      mockPrisma.refreshToken.findUnique.mockResolvedValue(storedToken);
+      mockPrisma.refreshToken.delete.mockResolvedValue(storedToken);
       const loginSpy = jest.spyOn(service, "login").mockResolvedValue({
         access_token: "new",
         refresh_token: "new-refresh",
@@ -189,12 +188,12 @@ describe("AuthService", () => {
 
       const result = await service.refreshTokens(plainToken);
 
-      expect(mockPrisma.authAccessToken.findUnique).toHaveBeenCalledWith({
+      expect(mockPrisma.refreshToken.findUnique).toHaveBeenCalledWith({
         where: { token: hashedToken },
         include: { admin: true },
       });
-      expect(mockPrisma.authAccessToken.delete).toHaveBeenCalledWith({
-        where: { id: 1 },
+      expect(mockPrisma.refreshToken.delete).toHaveBeenCalledWith({
+        where: { uuid: "3e19d992-2ea5-4ed3-9245-6691c41f4f06" },
       });
       expect(loginSpy).toHaveBeenCalledWith(mockAdmin);
       expect(result).toEqual({
@@ -204,7 +203,7 @@ describe("AuthService", () => {
     });
 
     it("should throw UnauthorizedException if token not found", async () => {
-      mockPrisma.authAccessToken.findUnique.mockResolvedValue(null);
+      mockPrisma.refreshToken.findUnique.mockResolvedValue(null);
 
       await expect(service.refreshTokens("invalid")).rejects.toThrow(
         UnauthorizedException,
@@ -213,17 +212,17 @@ describe("AuthService", () => {
 
     it("should throw and delete if token expired", async () => {
       const storedToken = {
-        id: 1,
+        uuid: "3e19d992-2ea5-4ed3-9245-6691c41f4f06",
         token: "expired-token",
         expiresAt: new Date(Date.now() - 10_000),
       };
-      mockPrisma.authAccessToken.findUnique.mockResolvedValue(storedToken);
+      mockPrisma.refreshToken.findUnique.mockResolvedValue(storedToken);
 
       await expect(service.refreshTokens("expired-token")).rejects.toThrow(
         UnauthorizedException,
       );
-      expect(mockPrisma.authAccessToken.delete).toHaveBeenCalledWith({
-        where: { id: 1 },
+      expect(mockPrisma.refreshToken.delete).toHaveBeenCalledWith({
+        where: { uuid: "3e19d992-2ea5-4ed3-9245-6691c41f4f06" },
       });
     });
   });

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -35,6 +35,9 @@ describe("AuthService", () => {
       findUnique: jest.fn(),
       delete: jest.fn(),
     },
+    passwordResetToken: {
+      create: jest.fn(),
+    },
   };
 
   const mockJwtService = {
@@ -224,6 +227,33 @@ describe("AuthService", () => {
       expect(mockPrisma.refreshToken.delete).toHaveBeenCalledWith({
         where: { uuid: "3e19d992-2ea5-4ed3-9245-6691c41f4f06" },
       });
+    });
+  });
+  describe("passwordResetTokens", () => {
+    it("Should create a token if admin exists", async () => {
+      mockPrisma.admin.findUnique.mockResolvedValue({
+        uuid: "admin-uuid-123",
+      });
+
+      await service.forgotPassword("abc@example.com");
+
+      expect(mockPrisma.passwordResetToken.create).toHaveBeenCalledWith({
+        data: {
+          adminUuid: "admin-uuid-123",
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          token: expect.any(String),
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          expiresAt: expect.any(Date),
+        },
+      });
+    });
+
+    it("Shouldn't create a token if admin does not exist", async () => {
+      mockPrisma.admin.findUnique.mockResolvedValue(null);
+
+      await service.forgotPassword("abc@example.com");
+
+      expect(mockPrisma.passwordResetToken.create).toHaveBeenCalledTimes(0);
     });
   });
 });

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -2,7 +2,11 @@ import * as bcrypt from "bcrypt";
 import { createHash } from "node:crypto";
 import type { Admin } from "src/generated/prisma/client";
 
-import { ConflictException, UnauthorizedException } from "@nestjs/common";
+import {
+  BadRequestException,
+  ConflictException,
+  UnauthorizedException,
+} from "@nestjs/common";
 import { JwtService } from "@nestjs/jwt";
 import type { TestingModule } from "@nestjs/testing";
 import { Test } from "@nestjs/testing";
@@ -29,15 +33,20 @@ describe("AuthService", () => {
     admin: {
       findUnique: jest.fn(),
       create: jest.fn(),
+      update: jest.fn(),
     },
     refreshToken: {
       create: jest.fn(),
       findUnique: jest.fn(),
       delete: jest.fn(),
+      deleteMany: jest.fn(),
     },
     passwordResetToken: {
       create: jest.fn(),
+      findUnique: jest.fn(),
+      deleteMany: jest.fn(),
     },
+    $transaction: jest.fn(),
   };
 
   const mockJwtService = {
@@ -229,7 +238,7 @@ describe("AuthService", () => {
       });
     });
   });
-  describe("passwordResetTokens", () => {
+  describe("forgotPassword", () => {
     it("Should create a token if admin exists", async () => {
       mockPrisma.admin.findUnique.mockResolvedValue({
         uuid: "admin-uuid-123",
@@ -254,6 +263,55 @@ describe("AuthService", () => {
       await service.forgotPassword("abc@example.com");
 
       expect(mockPrisma.passwordResetToken.create).toHaveBeenCalledTimes(0);
+    });
+  });
+  describe("resetPassword", () => {
+    it("Should reset password", async () => {
+      mockPrisma.passwordResetToken.findUnique.mockResolvedValue({
+        adminUuid: "admin-uuid",
+        expiresAt: new Date(Date.now() + 100_000_000),
+      });
+
+      jest
+        .spyOn(bcrypt, "hash")
+        .mockImplementation(() => "hashed-password-123");
+
+      mockPrisma.$transaction.mockResolvedValue([]);
+
+      await service.resetPassword("token-123", "Password123!?");
+
+      expect(bcrypt.hash).toHaveBeenCalledWith("Password123!?", 12);
+      expect(mockPrisma.$transaction).toHaveBeenCalledTimes(1);
+      expect(mockPrisma.$transaction).toHaveBeenCalledWith(expect.any(Array));
+      expect(mockPrisma.refreshToken.deleteMany).toHaveBeenCalledWith({
+        where: { adminUuid: "admin-uuid" },
+      });
+      expect(mockPrisma.passwordResetToken.deleteMany).toHaveBeenCalledWith({
+        where: { adminUuid: "admin-uuid" },
+      });
+      expect(mockPrisma.admin.update).toHaveBeenCalledWith({
+        where: { uuid: "admin-uuid" },
+        data: { password: "hashed-password-123" },
+      });
+    });
+    it("Should throw BadRequestException if token doesn't exist", async () => {
+      mockPrisma.passwordResetToken.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.resetPassword("bad-token-123", "newPassword22"),
+      ).rejects.toThrow(BadRequestException);
+      expect(mockPrisma.$transaction).toHaveBeenCalledTimes(0);
+    });
+    it("Should throw BadRequestException if token expired", async () => {
+      mockPrisma.passwordResetToken.findUnique.mockResolvedValue({
+        adminUuid: "admin-uuid",
+        expiresAt: new Date(Date.now() - 100_000_000),
+      });
+
+      await expect(
+        service.resetPassword("token-123", "new-pass-123"),
+      ).rejects.toThrow(BadRequestException);
+      expect(mockPrisma.$transaction).toHaveBeenCalledTimes(0);
     });
   });
 });

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -126,7 +126,6 @@ export class AuthService {
         },
       });
       // !!! TODO: ADD EMAIL SENDING !!!
-      console.warn(resetToken);
     }
   }
 

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -108,4 +108,23 @@ export class AuthService {
     });
     return this.login(storedToken.admin);
   }
+
+  async forgotPassword(email: string) {
+    const admin = await this.prisma.admin.findUnique({
+      where: { email },
+    });
+    if (admin !== null) {
+      const resetToken = randomBytes(64).toString("hex");
+      const hashedToken = createHash("sha256").update(resetToken).digest("hex");
+      const expiresAt = new Date(Date.now() + 15 * 60 * 1000); // 15 minutes
+      await this.prisma.passwordResetToken.create({
+        data: {
+          adminUuid: admin.uuid,
+          expiresAt,
+          token: hashedToken,
+        },
+      });
+      // !!! TODO: ADD EMAIL SENDING !!!
+    }
+  }
 }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -74,13 +74,10 @@ export class AuthService {
     const expiresAt = new Date();
     expiresAt.setDate(expiresAt.getDate() + 7); // 7 days
 
-    await this.prisma.authAccessToken.create({
+    await this.prisma.refreshToken.create({
       data: {
-        tokenableId: adminUuid,
-        type: "refresh_token",
+        adminUuid,
         token: hashedToken,
-        abilities: "*",
-        updatedAt: new Date(),
         expiresAt,
       },
     });
@@ -90,7 +87,7 @@ export class AuthService {
 
   async refreshTokens(token: string) {
     const hashedToken = createHash("sha256").update(token).digest("hex");
-    const storedToken = await this.prisma.authAccessToken.findUnique({
+    const storedToken = await this.prisma.refreshToken.findUnique({
       where: { token: hashedToken },
       include: { admin: true },
     });
@@ -100,13 +97,15 @@ export class AuthService {
     }
 
     if (storedToken.expiresAt < new Date()) {
-      await this.prisma.authAccessToken.delete({
-        where: { id: storedToken.id },
+      await this.prisma.refreshToken.delete({
+        where: { uuid: storedToken.uuid },
       });
       throw new UnauthorizedException("Expired refresh token");
     }
 
-    await this.prisma.authAccessToken.delete({ where: { id: storedToken.id } });
+    await this.prisma.refreshToken.delete({
+      where: { uuid: storedToken.uuid },
+    });
     return this.login(storedToken.admin);
   }
 }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -3,6 +3,7 @@ import { createHash, randomBytes } from "node:crypto";
 import { Admin } from "src/generated/prisma/client";
 
 import {
+  BadRequestException,
   ConflictException,
   Injectable,
   UnauthorizedException,
@@ -125,6 +126,32 @@ export class AuthService {
         },
       });
       // !!! TODO: ADD EMAIL SENDING !!!
+      console.warn(resetToken);
     }
+  }
+
+  async resetPassword(token: string, password: string) {
+    const hashedToken = createHash("sha256").update(token).digest("hex");
+    const resetToken = await this.prisma.passwordResetToken.findUnique({
+      where: { token: hashedToken },
+    });
+
+    if (resetToken === null || resetToken.expiresAt.getTime() < Date.now()) {
+      throw new BadRequestException("Invalid or expired token");
+    }
+    const hashedPassword = await bcrypt.hash(password, 12);
+
+    await this.prisma.$transaction([
+      this.prisma.admin.update({
+        where: { uuid: resetToken.adminUuid },
+        data: { password: hashedPassword },
+      }),
+      this.prisma.refreshToken.deleteMany({
+        where: { adminUuid: resetToken.adminUuid },
+      }),
+      this.prisma.passwordResetToken.deleteMany({
+        where: { adminUuid: resetToken.adminUuid },
+      }),
+    ]);
   }
 }

--- a/src/auth/dto/forgot-password.dto.ts
+++ b/src/auth/dto/forgot-password.dto.ts
@@ -1,5 +1,6 @@
-import { ApiProperty } from "@nestjs/swagger";
 import { IsEmail, IsNotEmpty } from "class-validator";
+
+import { ApiProperty } from "@nestjs/swagger";
 
 export class ForgotPasswordDto {
   @IsEmail()

--- a/src/auth/dto/forgot-password.dto.ts
+++ b/src/auth/dto/forgot-password.dto.ts
@@ -5,5 +5,5 @@ export class ForgotPasswordDto {
   @IsEmail()
   @IsNotEmpty()
   @ApiProperty({ example: "user@example.com" })
-  email: string;
+  email!: string;
 }

--- a/src/auth/dto/forgot-password.dto.ts
+++ b/src/auth/dto/forgot-password.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsEmail, IsNotEmpty } from "class-validator";
+
+export class ForgotPasswordDto {
+  @IsEmail()
+  @IsNotEmpty()
+  @ApiProperty({ example: "user@example.com" })
+  email: string;
+}

--- a/src/auth/dto/reset-password.dto.ts
+++ b/src/auth/dto/reset-password.dto.ts
@@ -1,5 +1,6 @@
-import { ApiProperty } from "@nestjs/swagger";
 import { IsNotEmpty, IsString, MaxLength, MinLength } from "class-validator";
+
+import { ApiProperty } from "@nestjs/swagger";
 
 export class ResetPasswordDto {
   @IsString()

--- a/src/auth/dto/reset-password.dto.ts
+++ b/src/auth/dto/reset-password.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsNotEmpty, IsString, MaxLength, MinLength } from "class-validator";
+
+export class ResetPasswordDto {
+  @IsString()
+  @ApiProperty({ example: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..." })
+  token!: string;
+
+  @ApiProperty({ example: "password123" })
+  @IsString()
+  @IsNotEmpty()
+  @MinLength(8)
+  @MaxLength(72) // bcrypt accepts max 72 characters for password
+  password!: string;
+}

--- a/src/blocks/blocks.service.ts
+++ b/src/blocks/blocks.service.ts
@@ -125,7 +125,7 @@ export class BlocksService {
     const blocksMap = new Map<string, Block>();
 
     for (const block of blocks) {
-      blocksMap.set(block.uuid, { ...block, children: [] } as Block);
+      blocksMap.set(block.uuid, { ...block, children: [] });
     }
 
     let rootBlock: Block | null = null;

--- a/src/emails/emails.service.spec.ts
+++ b/src/emails/emails.service.spec.ts
@@ -451,7 +451,7 @@ describe("EmailsService", () => {
       mockTransaction(mockPrismaService);
       mockPrismaService.emailTemplate.findFirst.mockResolvedValue(null);
       await expect(
-        service.update(mockEventId, mockEmailId, {} as UpdateEmailDto),
+        service.update(mockEventId, mockEmailId, {}),
       ).rejects.toThrow(NotFoundException);
     });
 
@@ -459,7 +459,7 @@ describe("EmailsService", () => {
       mockTransaction(mockPrismaService);
       mockPrismaService.emailTemplate.findFirst.mockResolvedValue(null);
       await expect(
-        service.update(mockEventId, mockEmailId, {} as UpdateEmailDto),
+        service.update(mockEventId, mockEmailId, {}),
       ).rejects.toThrow(NotFoundException);
     });
   });

--- a/src/forms/forms.service.spec.ts
+++ b/src/forms/forms.service.spec.ts
@@ -347,12 +347,7 @@ describe("FormsService", () => {
       jest.spyOn(service, "isOpen").mockResolvedValue(false);
 
       await expect(
-        service.formSubmit(
-          eventUuid,
-          formUuid,
-          { attributes: [] } as FormSubmitionDto,
-          [],
-        ),
+        service.formSubmit(eventUuid, formUuid, { attributes: [] }, []),
       ).rejects.toThrow(BadRequestException);
     });
 

--- a/src/forms/forms.service.ts
+++ b/src/forms/forms.service.ts
@@ -9,7 +9,6 @@ import {
   OpenCondition,
   Prisma,
 } from "src/generated/prisma/client";
-import { ParticipantAttributeDto } from "src/participants/dto/participant-create.dto";
 import { ParticipantUpdateDto } from "src/participants/dto/participant-update.dto";
 import { ParticipantsService } from "src/participants/participants.service";
 
@@ -837,11 +836,10 @@ export class FormsService {
         const participantDtoAttributes: ParticipantUpdateDto = {
           email: submissionData.email,
           participantAttributes: Object.entries(normalizedAttributes).map(
-            ([attributeUuid, value]) =>
-              ({
-                attributeUuid,
-                value,
-              }) as ParticipantAttributeDto,
+            ([attributeUuid, value]) => ({
+              attributeUuid,
+              value,
+            }),
           ),
         };
 

--- a/src/forms/utils/upload-files-decorator.ts
+++ b/src/forms/utils/upload-files-decorator.ts
@@ -10,8 +10,8 @@ export function UploadFiles(fieldName = "files", maxCount = 10) {
       FilesInterceptor(fieldName, maxCount, {
         storage: diskStorage({
           destination: (request, _file, callback) => {
-            const eventId = request.params.eventId;
-            const formId = request.params.id;
+            const eventId = request.params.eventId as string;
+            const formId = request.params.id as string;
             const uploadPath = `./uploads/forms/${eventId}/${formId}`;
             if (!existsSync(uploadPath)) {
               mkdirSync(uploadPath, { recursive: true });


### PR DESCRIPTION
closes #76 

- Tokeny maja żywotność 15 minut
- co do samych tokenów:
dopóki nie zresetujemy hasła, to zostają one w bazie (czyli trzymamy expired tokeny), czyścimy je tylko przy resecie hasła, wiec teoretycznie da sie ich naspamować (nie wiem na ile to może być problem w przyszlości), możnaby zrobić jakiegoś crona który by czyscił expired tokeny, albo przy tworzeniu tokena usuwać wszystkie pozostałe dla tego admina (wtedy moze byc aktywny tylko jeden, ten najnowszy)
- Maile są TODO
- lint mi jeszcze nie wiem czemu narzekal na inne moduly i sam je pozmienial (???), prettier narzekal tez na kolejnosc importow, i nie chcial mi jej sam lokalnie naprawic, dlatego taki syf w commitach xD (nie wiem co tu sie podzialo, za dlugo z tym walczylem 😭)