### PR TITLE
fix: allow email in attributes config

### DIFF
--- a/src/attributes/attributes.service.spec.ts
+++ b/src/attributes/attributes.service.spec.ts
@@ -164,4 +164,52 @@ describe("AttributesService", () => {
       },
     });
   });
+
+  it("should allow email in block participantFields", async () => {
+    const eventId = "event-uuid";
+
+    mockPrismaService.$transaction.mockImplementation(async (callback) => {
+      return await callback(mockPrismaService);
+    });
+    mockPrismaService.event.findUnique.mockResolvedValue({ uuid: eventId });
+    mockPrismaService.attribute.create.mockResolvedValue({
+      uuid: "attribute-uuid",
+      name: "Block attribute",
+      order: 1,
+      showInList: true,
+      type: AttributeType.block,
+      eventUuid: eventId,
+      config: {
+        maxSelections: 1,
+        participantFields: ["550e8400-e29b-41d4-a716-446655440000", "email"],
+      },
+    });
+
+    await service.create(
+      {
+        name: "Block attribute",
+        order: 1,
+        showInList: true,
+        type: AttributeType.block,
+        config: {
+          participantFields: ["550e8400-e29b-41d4-a716-446655440000", "email"],
+        },
+      },
+      eventId,
+    );
+
+    expect(mockPrismaService.attribute.create).toHaveBeenCalledWith({
+      data: {
+        name: "Block attribute",
+        order: 1,
+        showInList: true,
+        type: AttributeType.block,
+        eventUuid: eventId,
+        config: {
+          maxSelections: 1,
+          participantFields: ["550e8400-e29b-41d4-a716-446655440000", "email"],
+        },
+      },
+    });
+  });
 });

--- a/src/attributes/attributes.service.ts
+++ b/src/attributes/attributes.service.ts
@@ -135,16 +135,20 @@ export class AttributesService {
           );
         }
 
-        const invalidParticipantField = participantFields.find(
-          (uuid) => !isUUID(uuid),
+        const normalizedParticipantFields = participantFields.map((field) =>
+          field.trim(),
+        );
+
+        const invalidParticipantField = normalizedParticipantFields.find(
+          (field) => field !== "email" && !isUUID(field),
         );
         if (invalidParticipantField !== undefined) {
           throw new BadRequestException(
-            `Attribute config field participantFields contains an invalid uuid: ${invalidParticipantField}`,
+            `Attribute config field participantFields contains an invalid value: ${invalidParticipantField}`,
           );
         }
 
-        normalizedConfig.participantFields = participantFields;
+        normalizedConfig.participantFields = normalizedParticipantFields;
       }
 
       return normalizedConfig as Prisma.InputJsonValue;


### PR DESCRIPTION
### Co dodane
- sprawdza czy w participantFields jest valid id LUB "email"
- test są (nawet przechodzą)
- śmiga dla create i patch
### Pokaz slajdów
<img width="563" height="367" alt="image" src="https://github.com/user-attachments/assets/f3b01e38-a4b0-470c-8b67-1de658309236" />

### Rozkminka
Nie wiem czy poszedł fix do formatowania, ale go nie puściłem z konsoli i przy commitowaniu się sam zrobił (i nawet działa!!!)